### PR TITLE
Output true srcset, not data-srcset

### DIFF
--- a/__tests__/plugins/resources/f-image-srcset-1.html
+++ b/__tests__/plugins/resources/f-image-srcset-1.html
@@ -9,4 +9,4 @@
 {@|image-srcset 1}
 
 :OUTPUT
-data-srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w"
+srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w"

--- a/src/plugins/formatters.content.ts
+++ b/src/plugins/formatters.content.ts
@@ -204,7 +204,7 @@ export class ImageMetaSrcSetFormatter extends Formatter {
     }
 
     const _variants = variants.map(v => `${assetUrl}?format=${v} ${v}`).join(',');
-    const text = ` data-srcset="${_variants}"`;
+    const text = ` srcset="${_variants}"`;
     first.set(text);
   }
 }


### PR DESCRIPTION
Completes [CMS-38077](https://jira.squarespace.net/browse/CMS-38077) . The `|image-srcset` formatter will now return the standard `srcset` attribute to be picked up by [modern browsers](https://caniuse.com/srcset). ImageLoader will be updated to operate on this attribute for unsupported browsers rather than `data-srcset`.

Ahead of this work, it was determined that template-engine is not yet processing any JSON-T that uses the image-srcset formatter.