### PR TITLE
Expressions: detect unbalanced parenthesis

### DIFF
--- a/__tests__/math.test.ts
+++ b/__tests__/math.test.ts
@@ -66,6 +66,12 @@ test('basics', () => {
   expect(build(e)).toEqual([]);
   expect(reduce(e, c)).toEqual(undefined);
 
+  // if no operators are applied, the result is the top of the RPN stack
+  e = '1 2 3 4 5'
+  expect(parse(e)).toEqual([num(1), num(2), num(3), num(4), num(5)]);
+  expect(build(e)).toEqual([[num(1), num(2), num(3), num(4), num(5)]]);
+  expect(reduce(e, c)).toEqual(new Node(5));
+
   e = '1+2';
   expect(parse(e)).toEqual([num(1), ADD, num(2)]);
   expect(build(e)).toEqual([[num(1), num(2), ADD]]);
@@ -793,6 +799,16 @@ test('function calls', () => {
 
   // missing nodes will reduce to null
   expect(reduce('missing', c)).toEqual(new Node(null));
+});
+
+test('function args boundary', () => {
+  const c = context({});
+
+  expect(build('max(1, 2) 123')).toEqual([[ARGS, num(1), num(2), call('max'), num(123)]]);
+  expect(reduce('max(1, 2) 123', c)).toEqual(new Node(123));
+
+  expect(build('max(2) 1')).toEqual([[ARGS, num(2), call('max'), num(1)]]);
+  expect(reduce('max(2) 1', c)).toEqual(new Node(1));
 });
 
 test('type conversions', () => {

--- a/__tests__/math.test.ts
+++ b/__tests__/math.test.ts
@@ -20,6 +20,7 @@ import {
   ASN,
   SEMI,
   SEQ,
+  VarToken,
   ExprOptions,
 } from '../src/math';
 import { splitVariable } from '../src/util';
@@ -43,7 +44,7 @@ const build = (s: string) => {
 const parse = (s: string) => new Expr(s).tokens.elems;
 
 const call = (value: string) => ({ type: ExprTokenType.CALL, value });
-const varn = (value: string) => ({
+const varn = (value: string): VarToken => ({
   type: ExprTokenType.VARIABLE,
   value: splitVariable(value),
 });
@@ -265,6 +266,26 @@ test('unsupported values', () => {
   expect(reduce('num(arr)', c)).toEqual(undefined);
   expect(reduce('str(arr)', c)).toEqual(undefined);
   expect(reduce('bool(arr)', c)).toEqual(undefined);
+});
+
+test('unsupported operators', () => {
+  let c: Context = new Context(new Node({}));
+  let e: Expr;
+
+  // Reduce invalid expressions to ensure that unexpected operators are caught
+  // during evaluation.
+
+  e = new Expr('');
+  e.reduceExpr(c, [num(1), num(2), SEMI]);
+  expect(e.errors[0]).toContain('Unexpected operator');
+
+  e = new Expr('');
+  e.reduceExpr(c, [num(1), num(2), LPRN]);
+  expect(e.errors[0]).toContain('Unexpected operator');
+
+  e = new Expr('');
+  e.reduceExpr(c, [varn('@foo'), num(1), num(2), ADD, LPRN, ASN]);
+  expect(e.errors[0]).toContain('Unexpected operator');
 });
 
 test('strings', () => {

--- a/__tests__/math.test.ts
+++ b/__tests__/math.test.ts
@@ -584,8 +584,33 @@ test('nesting', () => {
   expect(reduce('((1 + 2) * 3) ** 2', c)).toEqual(new Node(81));
 
   // errant right parens
-  expect(reduce('1 )', c)).toEqual(new Node(1));
+  expect(reduce('1 )', c)).toEqual(undefined);
   expect(reduce('1 + ) 2', c)).toEqual(undefined);
+});
+
+test('balanced parens', () => {
+  let c = context({});
+  let e: Expr;
+
+  e = new Expr('@foo = (1 + 2');
+  e.build();
+  expect(e.errors[0]).toContain('Mismatched');
+
+  e = new Expr('(1 + 2');
+  e.build();
+  expect(e.errors[0]).toContain('Mismatched');
+
+  e = new Expr('1 + 2)');
+  e.build();
+  expect(e.errors[0]).toContain('Mismatched');
+
+  e = new Expr('((1 + 2)');
+  e.build();
+  expect(e.errors[0]).toContain('Mismatched');
+
+  e = new Expr('(1 + 2))');
+  e.build();
+  expect(e.errors[0]).toContain('Mismatched');
 });
 
 test('shift', () => {

--- a/src/math.ts
+++ b/src/math.ts
@@ -1071,6 +1071,12 @@ export class Expr {
               }
 
               ops.pop();
+
+              // If a function call token preceeded the left parenthesis, pop it to the output
+              ({ top } = ops);
+              if (top && top.type === ExprTokenType.CALL) {
+                out.push(ops.pop()!);
+              }
               break;
             }
 

--- a/src/math.ts
+++ b/src/math.ts
@@ -130,7 +130,8 @@ const E_INVALID_HEX = `Invalid 2-char hex escape found`;
 const E_INVALID_UNICODE = `Invalid unicode escape found`;
 // const E_INVALID_HEX_NUM = 'Invalid hex number sequence';
 // const E_INVALID_DEC_NUM = 'Invalid decimal number sequence';
-const E_MISMATCHED_OP = `Mismatched operator found: `;
+const E_MISMATCHED_OP = `Mismatched operator found:`;
+const E_UNEXPECTED_OPERATOR = `Unexpected operator found during evaluation:`;
 
 // Operator associativity
 export const enum Assoc {
@@ -695,7 +696,7 @@ const mul = (a: Token, b: Token): Token => num(asnum(a) * asnum(b));
 const matcher = new ExprMatcherImpl('');
 
 // Uncomment to debug tokens
-// const debug = (t: Token | undefined): string => {
+// export const debug = (t: Token | undefined): string => {
 //   if (!t) {
 //     return 'undefined';
 //   }
@@ -879,9 +880,8 @@ export class Expr {
           // Validate operator args are present and valid
           if (a === undefined || b === undefined) {
             // Invalid arguments to operator, bail out.
-            const op = OPERATORS[t.value.type].desc;
             ctx.error(
-              expressionReduce(this.raw, `Invalid arguments to operator ${op}`)
+              expressionReduce(this.raw, `Invalid arguments to operator ${t.value.desc}`)
             );
             break loop;
           }
@@ -974,7 +974,11 @@ export class Expr {
             case OperatorType.LOR:
               r = bool(asbool(a) || asbool(b));
               break;
-          }
+            default:
+              this.errors.push(`${E_UNEXPECTED_OPERATOR} ${t.value.desc}`);
+              stack.top = undefined;
+              break loop;
+            }
           stack.push(r!);
         }
       }


### PR DESCRIPTION
All instances of mismatched parenthesis will now raise an appropriate error message.