### PR TITLE
Expressions: debug mode

### DIFF
--- a/__tests__/math.test.ts
+++ b/__tests__/math.test.ts
@@ -1,6 +1,7 @@
 import { Context } from '../src/context';
 import { Node } from '../src/node';
 import {
+  tokenDebug,
   ADD,
   ArgsToken,
   bool,
@@ -42,6 +43,9 @@ const build = (s: string) => {
 };
 
 const parse = (s: string) => new Expr(s).tokens.elems;
+
+const debug = (s: string) =>
+  '[' + build(s).map(e => '[' + e.map(tokenDebug).join(' ') + ']').join(', ') + ']';
 
 const call = (value: string) => ({ type: ExprTokenType.CALL, value });
 const varn = (value: string): VarToken => ({
@@ -170,6 +174,18 @@ test('basics', () => {
   ]);
   c = context({});
   expect(reduce(e, c)).toEqual(new Node(1.5));
+});
+
+test('debug', () => {
+  expect(debug('@a = 2 * 3 / max(c, d)'))
+    .toEqual('[[@a 2 3 <multiply> <args> c d max() <divide> <assign>]]');
+  expect(debug(`"foo" !== "bar"`))
+    .toEqual('[["foo" "bar" <strict inequality>]]');
+  expect(debug('null == false || null != true'))
+    .toEqual('[[null false <equality> null true <inequality> <logical or>]]');
+  expect(tokenDebug({ type: 100 }))
+    .toEqual('<unk>');
+  expect(tokenDebug(undefined)).toEqual('undefined');
 });
 
 test('limits', () => {

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -55,6 +55,8 @@ export interface EvalCode {
   [1]: string;
   // Property to store parsed expression during evaluation.
   expr?: any;
+  // Emit expression debug
+  debug?: boolean;
 }
 
 export interface IfCode {

--- a/src/math.ts
+++ b/src/math.ts
@@ -334,8 +334,8 @@ export const ASN = _op(OperatorType.ASN, 3, Assoc.RIGHT, 'assign');
 // fake operators
 export const SEMI = _op(OperatorType.SEMI, 1, Assoc.LEFT, 'semicolon');
 export const COMMA = _op(OperatorType.COMMA, 1, Assoc.RIGHT, 'comma');
-export const LPRN = _op(OperatorType.LPRN, 1, Assoc.LEFT, 'left parenthesis');
-export const RPRN = _op(OperatorType.RPRN, 1, Assoc.LEFT, 'right parenthesis');
+export const LPRN = _op(OperatorType.LPRN, 1, Assoc.LEFT, 'left paren');
+export const RPRN = _op(OperatorType.RPRN, 1, Assoc.LEFT, 'right paren');
 
 /**
  * Stack.
@@ -695,32 +695,31 @@ const mul = (a: Token, b: Token): Token => num(asnum(a) * asnum(b));
 
 const matcher = new ExprMatcherImpl('');
 
-// Uncomment to debug tokens
-// export const debug = (t: Token | undefined): string => {
-//   if (!t) {
-//     return 'undefined';
-//   }
-//   switch (t.type) {
-//     case ExprTokenType.BOOLEAN:
-//       return `bool(${t.value})`;
-//     case ExprTokenType.NULL:
-//       return `null`;
-//     case ExprTokenType.NUMBER:
-//       return `num(${t.value})`;
-//     case ExprTokenType.STRING:
-//       return `str(${JSON.stringify(t.value)})`;
-//     case ExprTokenType.OPERATOR:
-//       return `op(${t.value.desc})`;
-//     case ExprTokenType.VARIABLE:
-//       return `var(${t.value})`;
-//     case ExprTokenType.CALL:
-//       return `${t.value}()`;
-//     case ExprTokenType.ARGS:
-//       return `<args>`;
-//     default:
-//       return 'unknown';
-//   }
-// };
+export const tokenDebug = (t: Token | undefined): string => {
+  if (!t) {
+    return 'undefined';
+  }
+  switch (t.type) {
+    case ExprTokenType.BOOLEAN:
+      return t.value ? 'true' : 'false';
+    case ExprTokenType.NULL:
+      return `null`;
+    case ExprTokenType.NUMBER:
+      return numfmt(t.value);
+    case ExprTokenType.STRING:
+      return JSON.stringify(t.value);
+    case ExprTokenType.OPERATOR:
+      return `<${t.value.desc}>`;
+    case ExprTokenType.VARIABLE:
+      return `${t.value.join('.')}`;
+    case ExprTokenType.CALL:
+      return `${t.value}()`;
+    case ExprTokenType.ARGS:
+      return `<args>`;
+    default:
+      return '<unk>';
+  }
+};
 
 /**
  * Options to configure the expression engine.


### PR DESCRIPTION
This is a quick enhancement to allow developers to view a representation of the assembled RPN expression. To enable debug output prefix the expression with a single `#` character. 

Example:
```
{.eval # @a = min(E, 3); @a * PI}
```
Output:
```
EVAL=[[@a <args> 2.7182818284590450908 3 min() <assign>], [@a 3.141592653589793116 <multiply>]] -> 8.539734222673566
```