### PR TITLE
Include instruction as an incubating feature

### DIFF
--- a/__tests__/parser.test.ts
+++ b/__tests__/parser.test.ts
@@ -213,6 +213,22 @@ test('if', () => {
   expect(code).toEqual([O.ROOT, 1, [[O.TEXT, '{.if a || **}']], O.EOF]);
 });
 
+test('include', () => {
+  let { code } = parse('{.include foo.html suppress foo bar}');
+  expect(code).toEqual([O.ROOT, 1, [
+    [O.INCLUDE, 'foo.html', [['suppress', 'foo', 'bar'], ' ']],
+  ], O.EOF]);
+
+  ({ code } = parse('{.include}'));
+  expect(code).toEqual([O.ROOT, 1, [[O.TEXT, '{.include}']], O.EOF]);
+
+  ({ code } = parse('{.include }'));
+  expect(code).toEqual([O.ROOT, 1, [[O.TEXT, '{.include }']], O.EOF]);
+
+  ({ code } = parse('{.include a}'));
+  expect(code).toEqual([O.ROOT, 1, [[O.INCLUDE, 'a', [[], ' ']]], O.EOF]);
+});
+
 test('inject', () => {
   let { code } = parse('abc{.inject @foo ./messages-en_US.json a b c}def');
   expect(code).toEqual([O.ROOT, 1, [
@@ -346,7 +362,7 @@ test('predicate', () => {
 
   ({ code } = parse('{.equal?|}'));
   expect(code).toEqual([O.ROOT, 1, [
-    [O.PREDICATE, 'equal?', [[''], '|'], [], undefined]
+    [O.PREDICATE, 'equal?', [[], '|'], [], undefined]
   ], O.END]);
 
   ({ code } = parse('{.**?}'));

--- a/__tests__/pretty.test.ts
+++ b/__tests__/pretty.test.ts
@@ -17,7 +17,7 @@ test('basic', () => {
   expect(JSON.parse(actual)).toEqual(spec.TEMPLATE);
 });
 
-pathseq('ast-%N.html', 19).forEach(path => {
+pathseq('ast-%N.html', 20).forEach(path => {
   test(path, () => {
     const spec = loader.load(path);
     const actual = prettyJson(spec.TEMPLATE);

--- a/__tests__/resources/ast-20.html
+++ b/__tests__/resources/ast-20.html
@@ -1,0 +1,10 @@
+:TEMPLATE
+{.include foo.html}
+{.include foo.html output}
+
+:JSON
+[17, 1, [
+  [24, "foo.html", [[], " "]],
+  [0, "\n"],
+  [24, "foo.html", [["output"], " "]]
+], 18]

--- a/bin/templatec.js
+++ b/bin/templatec.js
@@ -110,7 +110,7 @@ const main = () => {
   const json = jsonpath ? JSON.parse(read(jsonpath)) : {};
   const partials = partpath ? JSON.parse(read(partpath)) : {};
 
-  const { ctx } = compiler.execute({ cldr, code, json, partials, enableExpr: true });
+  const { ctx } = compiler.execute({ cldr, code, json, partials, enableExpr: true, enableInclude: true });
   console.log(ctx.render());
   if (ctx.errors) {
     for (const err of ctx.errors) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -26,6 +26,7 @@ export interface ExecuteProps {
   now?: number;
   enableExpr?: boolean;
   exprOpts?: ExprOptions;
+  enableInclude?: boolean;
 }
 
 export interface ParseResult {
@@ -90,14 +91,14 @@ export class Compiler {
    */
   execute(props: ExecuteProps = DefaultExecuteProps): ExecuteResult {
     let code: string | Code = props.code;
-    const { cldr, now, json, partials, injects, enableExpr, exprOpts } = props;
+    const { cldr, now, json, partials, injects, enableExpr, exprOpts, enableInclude } = props;
     let errors: TemplateError[] = [];
 
     if (typeof code === 'string') {
       ({ code, errors } = this.parse(code));
     }
 
-    const ctx = new Context(json, { cldr, now, partials, injects, enableExpr, exprOpts });
+    const ctx = new Context(json, { cldr, now, partials, injects, enableExpr, exprOpts, enableInclude });
     ctx.parsefunc = (raw: string) => this.parse(raw);
     this.engine.execute(code, ctx);
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -55,6 +55,11 @@ export interface ContextProps {
    * Options to configure the expression engine
    */
   exprOpts?: ExprOptions;
+
+  /**
+   * Explicitly enable the {.include} instruction.
+   */
+  enableInclude?: boolean;
 }
 
 type ParseFunc = (s: string) => { code: Code; errors: TemplateError[] };
@@ -78,6 +83,7 @@ export class Context {
   readonly now?: number;
   readonly enableExpr?: boolean;
   readonly exprOpts?: ExprOptions;
+  readonly enableInclude?: boolean;
   readonly formatter?: MessageFormats;
 
   protected partials: Partials;
@@ -99,6 +105,7 @@ export class Context {
     this.now = props.now;
     this.enableExpr = props.enableExpr;
     this.exprOpts = props.exprOpts;
+    this.enableInclude = props.enableInclude;
 
     // Instance of @phensley/cldr interface CLDR providing cldr-based formatting for
     // a given locale. It is the caller's responsibility to set this. If not

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -67,6 +67,12 @@ export interface IfCode {
   [4]: Code | undefined;
 }
 
+export interface IncludeCode {
+  [0]: Opcode.INCLUDE;
+  [1]: string;
+  [2]: Arguments | FAST_NULL;
+}
+
 export interface InjectCode {
   [0]: Opcode.INJECT;
   [1]: string;
@@ -142,6 +148,7 @@ export type Code =
   | CtxvarCode
   | EvalCode
   | IfCode
+  | IncludeCode
   | InjectCode
   | MacroCode
   | OrPredicateCode
@@ -247,6 +254,12 @@ export class If extends BaseInstruction implements BlockInstruction {
 
   setAlternate(inst: Instruction): void {
     (this.code as IfCode)[4] = getCode(inst);
+  }
+}
+
+export class Include extends BaseInstruction {
+  constructor(name: string, args: Arguments | FAST_NULL) {
+    super(Opcode.INCLUDE, [Opcode.INCLUDE, name, args]);
   }
 }
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -15,7 +15,7 @@ const INSTRUCTIONS: { [x: string]: (string | Opcode)[] } = {
   'a': ['lternates with', Opcode.ALTERNATES_WITH],
   'c': ['tx', Opcode.CTXVAR],
   'e': ['nd', Opcode.END, 'of', Opcode.EOF, 'val', Opcode.EVAL],
-  'i': ['f', Opcode.IF, 'nject', Opcode.INJECT],
+  'i': ['f', Opcode.IF, 'nclude', Opcode.INCLUDE, 'nject', Opcode.INJECT],
   'm': ['acro', Opcode.MACRO, 'eta-left', Opcode.META_LEFT, 'eta-right', Opcode.META_RIGHT],
   'n': ['ewline', Opcode.NEWLINE],
   'o': ['r', Opcode.OR_PREDICATE],
@@ -172,7 +172,8 @@ export class Matcher implements MatcherProps {
     if (rawArgs !== null) {
       // Parse and append formatter with arguments.
       const delim = rawArgs[0];
-      return [rawArgs.slice(1).split(delim), delim];
+      const args = rawArgs.slice(1).split(delim);
+      return (args.length === 1 && !args[0]) ? [[], delim] : [args, delim];
     }
     return null;
   }

--- a/src/opcodes.ts
+++ b/src/opcodes.ts
@@ -33,7 +33,10 @@ export enum Opcode {
   CTXVAR = 22,
 
   // Evaluate expression
-  EVAL = 23
+  EVAL = 23,
+
+  // Include a macro / partial inline
+  INCLUDE = 24,
 }
 
 const NAMES = {
@@ -62,6 +65,7 @@ const NAMES = {
   [Opcode.ATOM]: 'ATOM',
   [Opcode.CTXVAR]: 'CTXVAR',
   [Opcode.EVAL]: 'EVAL',
+  [Opcode.INCLUDE]: 'INCLUDE',
 };
 
 export const nameOfOpcode = (opcode: Opcode) => {

--- a/src/pretty.ts
+++ b/src/pretty.ts
@@ -29,7 +29,8 @@ const STRUCTURE = [
   [0, 0, BLOCK], // STRUCT
   null, // ATOM
   null, // CTXVAR
-  null  // EVAL
+  null, // EVAL
+  null, // INCLUDE
 ];
 
 /**


### PR DESCRIPTION
This instruction will include the body of a partial template (or macro) inline as if it were pasted in. This enables local variables to be defined in a partial and be visible in the outer scope. By default all output generated by the partial template is suppressed.

Example:

Template: 
```
{.macro foo.html} pre {.var @a a} post {.end}

1. {.include foo.html}
value: {@a}

2. {.include foo.html output}
value: {@a}
```

JSON: `{ "a": 3.14159 }`

Output:
```
1.
value: 3.14159

2.  pre  post
value: 3.14159
```