### PR TITLE
I18NPROD-507-format-value-string-for-gift-card

### DIFF
--- a/__tests__/plugins/resources/f-variants-select-4.html
+++ b/__tests__/plugins/resources/f-variants-select-4.html
@@ -1,12 +1,12 @@
 :JSON
 {
   "localizedStrings": {
-    "giftCardVariantSelectText": "Get foobar"
+    "productVariantSelectText": "Get foobar"
   },
   "item": {
     "id": "560c37c1a7c8465c4a71d99a",
     "structuredContent": {
-      "productType": 4,
+      "productType": 1,
       "variants": [
         {"attributes": { "fit": "loose", "color": "blue" }},
         {"attributes": { "fit": "slim", "color": "red" }}
@@ -22,7 +22,7 @@
 :OUTPUT
 <div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;fit&quot;:&quot;loose&quot;,&quot;color&quot;:&quot;blue&quot;}},{&quot;attributes&quot;:{&quot;fit&quot;:&quot;slim&quot;,&quot;color&quot;:&quot;red&quot;}}]" data-animation-role="content">
     <div class="variant-option">
-    <div class="variant-option-title">Value: </div>
+    <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Get foobar" data-variant-option-name="fit">
         <option value="">Get foobar</option>
@@ -37,7 +37,7 @@
     </div>
     </div>
     <div class="variant-option">
-    <div class="variant-option-title">Value: </div>
+    <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Get foobar" data-variant-option-name="color">
         <option value="">Get foobar</option>

--- a/__tests__/plugins/resources/f-variants-select-4.html
+++ b/__tests__/plugins/resources/f-variants-select-4.html
@@ -22,7 +22,7 @@
 :OUTPUT
 <div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;fit&quot;:&quot;loose&quot;,&quot;color&quot;:&quot;blue&quot;}},{&quot;attributes&quot;:{&quot;fit&quot;:&quot;slim&quot;,&quot;color&quot;:&quot;red&quot;}}]" data-animation-role="content">
     <div class="variant-option">
-    <div class="variant-option-title">fit: </div>
+    <div class="variant-option-title">Value: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Get foobar" data-variant-option-name="fit">
         <option value="">Get foobar</option>
@@ -37,7 +37,7 @@
     </div>
     </div>
     <div class="variant-option">
-    <div class="variant-option-title">color: </div>
+    <div class="variant-option-title">Value: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Get foobar" data-variant-option-name="color">
         <option value="">Get foobar</option>

--- a/__tests__/plugins/resources/f-variants-select-5.html
+++ b/__tests__/plugins/resources/f-variants-select-5.html
@@ -1,7 +1,8 @@
 :JSON
 {
   "localizedStrings": {
-    "giftCardVariantSelectText": "Get foobar"
+    "giftCardVariantSelectText": "Get foobar",
+    "giftCardValueDisplayText": "Value Translated"
   },
   "item": {
     "id": "560c37c1a7c8465c4a71d99a",
@@ -22,7 +23,7 @@
 :OUTPUT
 <div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;fit&quot;:&quot;loose&quot;,&quot;color&amp;hue&quot;:&quot;blue&quot;}},{&quot;attributes&quot;:{&quot;fit&quot;:&quot;slim&quot;,&quot;color&amp;hue&quot;:&quot;red&quot;}}]" data-animation-role="content">
     <div class="variant-option">
-    <div class="variant-option-title">fit: </div>
+    <div class="variant-option-title">Value Translated: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Get foobar" data-variant-option-name="fit">
         <option value="">Get foobar</option>
@@ -37,7 +38,7 @@
     </div>
     </div>
     <div class="variant-option">
-    <div class="variant-option-title">color&amp;hue: </div>
+    <div class="variant-option-title">Value Translated: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Get foobar" data-variant-option-name="color&amp;hue">
         <option value="">Get foobar</option>

--- a/__tests__/plugins/resources/f-variants-select-5.html
+++ b/__tests__/plugins/resources/f-variants-select-5.html
@@ -37,7 +37,7 @@
     </div>
     </div>
     <div class="variant-option">
-    <div class="variant-option-title">color&hue: </div>
+    <div class="variant-option-title">color&amp;hue: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Select color&hue" data-variant-option-name="color&amp;hue">
         <option value="">Select color&hue</option>

--- a/__tests__/plugins/resources/f-variants-select-5.html
+++ b/__tests__/plugins/resources/f-variants-select-5.html
@@ -1,13 +1,12 @@
 :JSON
 {
-  "localizedStrings": {
-    "giftCardVariantSelectText": "Get foobar",
-    "giftCardValueDisplayText": "Value Translated"
+"localizedStrings": {
+    "productVariantSelectText": "Select {variantName}"
   },
   "item": {
     "id": "560c37c1a7c8465c4a71d99a",
     "structuredContent": {
-      "productType": 4,
+      "productType": 1,
       "variants": [
         {"attributes": { "fit": "loose", "color&hue": "blue" }},
         {"attributes": { "fit": "slim", "color&hue": "red" }}
@@ -23,10 +22,10 @@
 :OUTPUT
 <div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;fit&quot;:&quot;loose&quot;,&quot;color&amp;hue&quot;:&quot;blue&quot;}},{&quot;attributes&quot;:{&quot;fit&quot;:&quot;slim&quot;,&quot;color&amp;hue&quot;:&quot;red&quot;}}]" data-animation-role="content">
     <div class="variant-option">
-    <div class="variant-option-title">Value Translated: </div>
+    <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
-      <select aria-label="Get foobar" data-variant-option-name="fit">
-        <option value="">Get foobar</option>
+      <select aria-label="Select fit" data-variant-option-name="fit">
+        <option value="">Select fit</option>
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
@@ -38,10 +37,10 @@
     </div>
     </div>
     <div class="variant-option">
-    <div class="variant-option-title">Value Translated: </div>
+    <div class="variant-option-title">color&hue: </div>
     <div class="variant-select-wrapper">
-      <select aria-label="Get foobar" data-variant-option-name="color&amp;hue">
-        <option value="">Get foobar</option>
+      <select aria-label="Select color&hue" data-variant-option-name="color&amp;hue">
+        <option value="">Select color&hue</option>
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>

--- a/__tests__/plugins/resources/f-variants-select-6.html
+++ b/__tests__/plugins/resources/f-variants-select-6.html
@@ -1,18 +1,19 @@
 :JSON
 {
   "localizedStrings": {
+    "giftCardValueDisplayText": "Test Value",
     "giftCardVariantSelectText": "Get foobar"
   },
   "item": {
-    "id": "560c37c1a7c8465c4a71d99a",
-    "structuredContent": {
-      "productType": 4,
-      "variants": [
-        {"attributes": { "Attribute": "25" }},
-        {"attributes": { "Attribute": "50" }}
-      ],
-      "variantOptionOrdering": ["Attribute"]
-    }
+  "id": "560c37c1a7c8465c4a71d99a",
+  "structuredContent": {
+    "productType": 4,
+    "variants": [
+      {"attributes": { "Value": "25" }},
+      {"attributes": { "Value": "50" }}
+    ],
+  "variantOptionOrdering": ["Value"]
+  }
   }
 }
 
@@ -20,20 +21,20 @@
 {item|variants-select}
 
 :OUTPUT
-<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;25&quot;}},{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;50&quot;}}]" data-animation-role="content">
+<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Value&quot;:&quot;25&quot;}},{&quot;attributes&quot;:{&quot;Value&quot;:&quot;50&quot;}}]" data-animation-role="content">
     <div class="variant-option">
-    <div class="variant-option-title">Value: </div>
+    <div class="variant-option-title">Test Value: </div>
     <div class="variant-select-wrapper">
-      <select aria-label="Get foobar" data-variant-option-name="Attribute">
+      <select aria-label="Get foobar" data-variant-option-name="Value">
         <option value="">Get foobar</option>
         <option value="25">25</option><option value="50">50</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper" data-variant-option-name="Attribute">
-      <input type="radio" class="variant-radiobtn" value="25" name="variant-option-Attribute" id="variant-option-Attribute-25"/>
-      <label for="variant-option-Attribute-25">25</label>
-      <input type="radio" class="variant-radiobtn" value="50" name="variant-option-Attribute" id="variant-option-Attribute-50"/>
-      <label for="variant-option-Attribute-50">50</label>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="Value">
+      <input type="radio" class="variant-radiobtn" value="25" name="variant-option-Value" id="variant-option-Value-25"/>
+      <label for="variant-option-Value-25">25</label>
+      <input type="radio" class="variant-radiobtn" value="50" name="variant-option-Value" id="variant-option-Value-50"/>
+      <label for="variant-option-Value-50">50</label>
     </div>
     </div>
   </div>

--- a/__tests__/plugins/resources/f-variants-select-6.html
+++ b/__tests__/plugins/resources/f-variants-select-6.html
@@ -1,0 +1,39 @@
+:JSON
+{
+  "localizedStrings": {
+    "giftCardVariantSelectText": "Get foobar"
+  },
+  "item": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "structuredContent": {
+      "productType": 4,
+      "variants": [
+        {"attributes": { "Attribute": "25" }},
+        {"attributes": { "Attribute": "50" }}
+      ],
+      "variantOptionOrdering": ["Attribute"]
+    }
+  }
+}
+
+:TEMPLATE
+{item|variants-select}
+
+:OUTPUT
+<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;25&quot;}},{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;50&quot;}}]" data-animation-role="content">
+    <div class="variant-option">
+    <div class="variant-option-title">Value: </div>
+    <div class="variant-select-wrapper">
+      <select aria-label="Get foobar" data-variant-option-name="Attribute">
+        <option value="">Get foobar</option>
+        <option value="25">25</option><option value="50">50</option>
+      </select>
+    </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="Attribute">
+      <input type="radio" class="variant-radiobtn" value="25" name="variant-option-Attribute" id="variant-option-Attribute-25"/>
+      <label for="variant-option-Attribute-25">25</label>
+      <input type="radio" class="variant-radiobtn" value="50" name="variant-option-Attribute" id="variant-option-Attribute-50"/>
+      <label for="variant-option-Attribute-50">50</label>
+    </div>
+    </div>
+  </div>

--- a/__tests__/plugins/resources/f-variants-select-7.html
+++ b/__tests__/plugins/resources/f-variants-select-7.html
@@ -1,0 +1,40 @@
+:JSON
+{
+  "localizedStrings": {
+    "giftCardVariantSelectText": "Get foobar",
+    "productVariantSelectText": "Get {variantName}"
+  },
+  "item": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "structuredContent": {
+      "productType": 1,
+      "variants": [
+        {"attributes": { "Attribute": "25" }},
+        {"attributes": { "Attribute": "50" }}
+      ],
+      "variantOptionOrdering": ["Attribute"]
+    }
+  }
+}
+
+:TEMPLATE
+{item|variants-select}
+
+:OUTPUT
+<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;25&quot;}},{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;50&quot;}}]" data-animation-role="content">
+    <div class="variant-option">
+    <div class="variant-option-title">Attribute: </div>
+    <div class="variant-select-wrapper">
+      <select aria-label="Get Attribute" data-variant-option-name="Attribute">
+        <option value="">Get Attribute</option>
+        <option value="25">25</option><option value="50">50</option>
+      </select>
+    </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="Attribute">
+      <input type="radio" class="variant-radiobtn" value="25" name="variant-option-Attribute" id="variant-option-Attribute-25"/>
+      <label for="variant-option-Attribute-25">25</label>
+      <input type="radio" class="variant-radiobtn" value="50" name="variant-option-Attribute" id="variant-option-Attribute-50"/>
+      <label for="variant-option-Attribute-50">50</label>
+    </div>
+    </div>
+  </div>

--- a/__tests__/plugins/resources/f-variants-select-7.html
+++ b/__tests__/plugins/resources/f-variants-select-7.html
@@ -1,18 +1,18 @@
 :JSON
 {
   "localizedStrings": {
-    "giftCardVariantSelectText": "Get foobar",
-    "productVariantSelectText": "Get {variantName}"
+    "giftCardValueDisplayText": "Test Value",
+    "giftCardVariantSelectText": "Get foobar"
   },
   "item": {
     "id": "560c37c1a7c8465c4a71d99a",
     "structuredContent": {
       "productType": 1,
       "variants": [
-        {"attributes": { "Attribute": "25" }},
-        {"attributes": { "Attribute": "50" }}
+        {"attributes": { "Color": "Blue" }},
+        {"attributes": { "Color": "Pink" }}
       ],
-      "variantOptionOrdering": ["Attribute"]
+      "variantOptionOrdering": ["Color"]
     }
   }
 }
@@ -21,20 +21,20 @@
 {item|variants-select}
 
 :OUTPUT
-<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;25&quot;}},{&quot;attributes&quot;:{&quot;Attribute&quot;:&quot;50&quot;}}]" data-animation-role="content">
+<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Color&quot;:&quot;Blue&quot;}},{&quot;attributes&quot;:{&quot;Color&quot;:&quot;Pink&quot;}}]" data-animation-role="content">
     <div class="variant-option">
-    <div class="variant-option-title">Attribute: </div>
+    <div class="variant-option-title">Color: </div>
     <div class="variant-select-wrapper">
-      <select aria-label="Get Attribute" data-variant-option-name="Attribute">
-        <option value="">Get Attribute</option>
-        <option value="25">25</option><option value="50">50</option>
+      <select aria-label="Select Color" data-variant-option-name="Color">
+        <option value="">Select Color</option>
+        <option value="Blue">Blue</option><option value="Pink">Pink</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper" data-variant-option-name="Attribute">
-      <input type="radio" class="variant-radiobtn" value="25" name="variant-option-Attribute" id="variant-option-Attribute-25"/>
-      <label for="variant-option-Attribute-25">25</label>
-      <input type="radio" class="variant-radiobtn" value="50" name="variant-option-Attribute" id="variant-option-Attribute-50"/>
-      <label for="variant-option-Attribute-50">50</label>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="Color">
+      <input type="radio" class="variant-radiobtn" value="Blue" name="variant-option-Color" id="variant-option-Color-Blue"/>
+      <label for="variant-option-Color-Blue">Blue</label>
+      <input type="radio" class="variant-radiobtn" value="Pink" name="variant-option-Color" id="variant-option-Color-Pink"/>
+      <label for="variant-option-Color-Pink">Pink</label>
     </div>
     </div>
   </div>

--- a/__tests__/plugins/resources/get-item-variant-options.json
+++ b/__tests__/plugins/resources/get-item-variant-options.json
@@ -80,4 +80,21 @@
     {"name": "color", "values": ["blue", "red"]}
 ]
 
+:getItemVariant-6
+{
+    "id": "560c37c1a7c8465c4a71d99a",
+    "structuredContent": {
+      "variants": [
+        {"attributes": { "Value": "25" }},
+        {"attributes": { "Value": "50" }}
+      ],
+    "variantOptionOrdering": ["Value"]
+  }
+}
+
+:getItemVariant-6-expected
+[
+    {"name": "Value", "values": ["25", "50"]}
+]
+
 

--- a/src/plugins/formatters.commerce.ts
+++ b/src/plugins/formatters.commerce.ts
@@ -329,10 +329,12 @@ export class VariantsSelectFormatter extends Formatter {
     }
 
     const selectText = this.getSelectText(ctx, first.node);
+    const displayText = this.getDisplayText(ctx, first.node);
     const node = ctx.newNode({
       item: first.node.value,
       options,
       selectText,
+      displayText
     });
 
     const text = executeTemplate(
@@ -342,6 +344,24 @@ export class VariantsSelectFormatter extends Formatter {
       false
     );
     first.set(text);
+  }
+
+  private getDisplayText(ctx: Context, node: Node): string {
+    const productType = commerceutil.getProductType(node);
+    // Gift Cards have variants forcibly named "Value" by default (as opposed to a merchant-defined variant name) and
+    // thus must be translated directly before being displayed to the front-end.
+    let text = '';
+
+    // TODO: still need to implement message formatting in typescript compiler
+    let fallback = 'Value';
+    if (productType === ProductType.GIFT_CARD) {
+      text = ctx
+          .resolve(['localizedStrings', 'giftCardValueDisplayText'])
+          .asString();
+    } else {
+      fallback = '{name}';
+    }
+    return stringutil.defaultIfEmpty(text, fallback);
   }
 
   private getSelectText(ctx: Context, node: Node): string {

--- a/src/plugins/templates/variants-select.html
+++ b/src/plugins/templates/variants-select.html
@@ -6,7 +6,7 @@
 
   <div class="product-variants" data-item-id="{item.id}" data-variants="{@variants|json|htmltag}"{.if @isSubscribable} data-is-subscribable="true" data-subscription-plan="{@subscriptionPlan|json|htmltag}"{.end} data-animation-role="content">{.repeated section options}
     <div class="variant-option">
-    <div class="variant-option-title">{displayName|message name:name|htmltag}: </div>
+    <div class="variant-option-title">{displayText|message name:name|htmltag}: </div>
     <div class="variant-select-wrapper">
       <select aria-label="{selectText|message variantName:name}" data-variant-option-name="{name|htmltag}">
         <option value="">{selectText|message variantName:name}</option>

--- a/src/plugins/templates/variants-select.html
+++ b/src/plugins/templates/variants-select.html
@@ -6,7 +6,7 @@
 
   <div class="product-variants" data-item-id="{item.id}" data-variants="{@variants|json|htmltag}"{.if @isSubscribable} data-is-subscribable="true" data-subscription-plan="{@subscriptionPlan|json|htmltag}"{.end} data-animation-role="content">{.repeated section options}
     <div class="variant-option">
-    <div class="variant-option-title">{name|htmltag}: </div>
+    <div class="variant-option-title">{displayName|message name:name|htmltag}: </div>
     <div class="variant-select-wrapper">
       <select aria-label="{selectText|message variantName:name}" data-variant-option-name="{name|htmltag}">
         <option value="">{selectText|message variantName:name}</option>

--- a/src/plugins/templates/variants-select.json
+++ b/src/plugins/templates/variants-select.json
@@ -21,7 +21,7 @@
       [0, " data-animation-role=\"content\">"],
       [4, ["options"], [
           [0, "\n    <div class=\"variant-option\">\n    <div class=\"variant-option-title\">"],
-          [1, [["name"]], [["htmltag"]]],
+          [1, [["displayText"]], [["message", [["name:name"], " "]]], [["htmltag"]]],
           [0, ": </div>\n    <div class=\"variant-select-wrapper\">\n      <select aria-label=\""],
           [1, [["selectText"]], [["message", [["variantName:name"], " "]]]],
           [0, "\" data-variant-option-name=\""],

--- a/src/plugins/templates/variants-select.json
+++ b/src/plugins/templates/variants-select.json
@@ -21,7 +21,7 @@
       [0, " data-animation-role=\"content\">"],
       [4, ["options"], [
           [0, "\n    <div class=\"variant-option\">\n    <div class=\"variant-option-title\">"],
-          [1, [["displayText"]], [["message", [["name:name"], " "]]], [["htmltag"]]],
+          [1, [["displayText"]], [["message", [["name:name"], " "]], ["htmltag"]]],
           [0, ": </div>\n    <div class=\"variant-select-wrapper\">\n      <select aria-label=\""],
           [1, [["selectText"]], [["message", [["variantName:name"], " "]]]],
           [0, "\" data-variant-option-name=\""],


### PR DESCRIPTION
## What does this PR do?

Adds a method to `formatters.commerce.ts` that translates the "Value" string displayed when a product is a gift card and defaults to the user input variant name otherwise.

## Why is this important?

Currently there is a bug where the text above the gift card option drop-down displayed "Value" in English in all languages. This formatting method solves this bug.

## What high level changes did you make to the code to accomplish that goal?

* Added a method to `formatters.commerce.ts` that resolves the `displayText` based on the locale if a product is a gift card type otherwise it returns the `name` of the variant
* Changed the `variant-option-title` tag within `variants-select.html` and `variants-select.json` to `{displayName}` with a default to `name` for non-gift card product types.

## Anything else?

This change also required adding the string `Value` to the `products-en-US.json` and `products-2.0-en-US.json` files within site-server to be translated into all languages. That PR can be found [here](https://github.com/sqsp/squarespace-v6/pull/11407) and will need to be merged and have translations returned before these changes are incorporated. This change keeps template-engine parallel with template-compiler. The equivalent changes made in template-compiler can be found in [this PR](https://github.com/Squarespace/template-compiler/pull/26).

## How was this tested?

- [x] Wrote additional tests for this functionality 