### PR TITLE
PERF-2091: Ensure all srcset image candidate has width descriptor

### DIFF
--- a/__tests__/plugins/resources/f-image-srcset-1.html
+++ b/__tests__/plugins/resources/f-image-srcset-1.html
@@ -9,4 +9,4 @@
 {@|image-srcset 1}
 
 :OUTPUT
-srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w,/foo/bar.jpg?format=original"
+srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w,/foo/bar.jpg?format=original 2500w"

--- a/__tests__/plugins/resources/f-image-srcset-4.html
+++ b/__tests__/plugins/resources/f-image-srcset-4.html
@@ -1,0 +1,12 @@
+:JSON
+{
+  "assetUrl": "/foo/bar.jpg",
+  "systemDataVariants": "1500x983,100w,300w,500w,750w,1000w,1500w,2500w"
+}
+
+
+:TEMPLATE
+{@|image-srcset 1}
+
+:OUTPUT
+srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w,/foo/bar.jpg?format=2500w 2500w"

--- a/src/plugins/formatters.content.ts
+++ b/src/plugins/formatters.content.ts
@@ -20,6 +20,8 @@ import { hexColorToInt } from './util.color';
 // Template imports
 import audioPlayerTemplate from './templates/audio-player.json';
 
+const SQUARESPACE_SIZES = ['100w', '300w', '500w', '750w', '1000w', '1500w', '2500w'];
+
 export class AbsUrlFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {
     const first = vars[0];
@@ -199,8 +201,21 @@ export class ImageMetaSrcSetFormatter extends Formatter {
       return;
     }
 
+    let originalImageFormatVariant = '';
+    const lastVariant = variants[variants.length - 1];
+    if (lastVariant !== SQUARESPACE_SIZES[SQUARESPACE_SIZES.length - 1]) {
+      // If the largest variant is not the largest available resolution.
+      for (let i = SQUARESPACE_SIZES.length - 2; i >= 0; i--) {
+        if (lastVariant === SQUARESPACE_SIZES[i]) {
+          // Append the original image as the next size up
+          originalImageFormatVariant = `,${assetUrl}?format=original ${SQUARESPACE_SIZES[i + 1]}`;
+          break;
+        }
+      }
+    }
+
     const _variants = variants.map(v => `${assetUrl}?format=${v} ${v}`).join(',');
-    const text = ` srcset="${_variants},${assetUrl}?format=original"`;
+    const text = ` srcset="${_variants}${originalImageFormatVariant}"`;
     first.set(text);
   }
 }


### PR DESCRIPTION
We are currently adding orignal image candidate to srcset without width descriptor. This PR adds the next Squarespace image size width descriptor to srcset's original image candidate and avoid adding original image candidate if 2500w is already set because 2500w is already the biggest size we support (it is probably same image as orginal too). 

According to scrset spec https://html.spec.whatwg.org/multipage/images.html#image-candidate-string, srcset attribute for original image format should have width descriptor for our case.

> If an image candidate string for an element has the width descriptor specified, all other image candidate strings for that element must also have the width descriptor specified.

> If an element has a sizes attribute present, all image candidate strings for that element must have the width descriptor specified.

Our srcset attribute has all the width descriptor except for the last original format. This has caused some unexpected behavior. 

1.  In device with device pixel ratio of 1, original image is always requested instead of based on screen width. See screenshot below for https://www.akashagoods.com/ with DPR set to 1.0
![Screen Shot 2021-08-19 at 12 22 46 PM](https://user-images.githubusercontent.com/59619684/130127683-d19bfd0c-d5dd-422a-821e-aa0b815ca532.png)

2. In desktop mode, and for some websites, although 2500w image is available, chrome will choose orignal image instead 2500w image. See screenshots for https://cobalt-dog-78tl.squarespace.com/
![Screen Shot 2021-08-19 at 12 25 15 PM](https://user-images.githubusercontent.com/59619684/130127748-6f84d45c-88b8-42f6-af61-b481cc292469.png)

The last original image src should always have width descriptor to avoid these unexpected behavior.