### PR TITLE
[CMS-45395] - add website-color formatter in TypeScript template engine

### DIFF
--- a/__tests__/plugins/formatters.content.test.ts
+++ b/__tests__/plugins/formatters.content.test.ts
@@ -276,3 +276,7 @@ test('width', () => {
   impl.apply([], vars, CTX);
   expect(vars[0].node).toBe(MISSING_NODE);
 });
+
+loader.paths('f-website-color-%N.html').forEach((path) => {
+  test(`website-color - ${path}`, () => loader.execute(path));
+});

--- a/__tests__/plugins/resources/f-website-color-1.html
+++ b/__tests__/plugins/resources/f-website-color-1.html
@@ -1,0 +1,15 @@
+:JSON
+{
+    "hue": 200,
+    "saturation": 0.3,
+    "lightness": 0.5,
+    "alpha": 0.9
+}
+
+:TEMPLATE
+{@|website-color}
+
+:OUTPUT
+
+hsla(200, 30%, 50%, 0.9)
+

--- a/__tests__/plugins/resources/f-website-color-2.html
+++ b/__tests__/plugins/resources/f-website-color-2.html
@@ -1,0 +1,14 @@
+:JSON
+{
+    "hue": 110,
+    "saturation": 0.9,
+    "lightness": 1
+}
+
+:TEMPLATE
+{@|website-color}
+
+:OUTPUT
+
+hsl(110, 90%, 100%)
+

--- a/__tests__/plugins/resources/f-website-color-3.html
+++ b/__tests__/plugins/resources/f-website-color-3.html
@@ -1,0 +1,13 @@
+:JSON
+{
+    "saturation": 0.9,
+    "lightness": 1
+}
+
+:TEMPLATE
+{@|website-color}
+
+:OUTPUT
+
+Missing an H/S/L value.
+

--- a/__tests__/plugins/resources/f-website-color-4.html
+++ b/__tests__/plugins/resources/f-website-color-4.html
@@ -1,0 +1,15 @@
+:JSON
+{
+    "hue": 400,
+    "saturation": -0.3,
+    "lightness": 5,
+    "alpha": 3
+}
+
+:TEMPLATE
+{@|website-color}
+
+:OUTPUT
+
+Hue out of bounds. Saturation out of bounds. Lightness out of bounds. Alpha out of bounds.
+

--- a/src/plugins/formatters.content.ts
+++ b/src/plugins/formatters.content.ts
@@ -346,6 +346,81 @@ export class SquarespaceThumbnailForHeightFormatter extends Formatter {
   }
 }
 
+export class WebsiteColorFormatter extends Formatter {
+  apply(args: string[], vars: Variable[], ctx: Context): void {
+    const first = vars[0];
+    let hasAlphaValue = false;
+    let errorMessage = '';
+
+    const hueNode = first.node.get('hue');
+    const saturationNode = first.node.get('saturation');
+    const lightnessNode = first.node.get('lightness');
+
+    if (hueNode.isMissing() || saturationNode.isMissing() || lightnessNode.isMissing()) {
+      first.set('Missing an H/S/L value.');
+      return;
+    }
+
+    const hue = hueNode.asNumber();
+    let saturation = saturationNode.asNumber();
+    let lightness = lightnessNode.asNumber();
+    const alphaNode = first.node.get('alpha');
+    let alpha = null;
+    if (!alphaNode.isMissing()) {
+      hasAlphaValue = true;
+      alpha = alphaNode.asNumber();
+    }
+
+    if (hue < 0 || hue > 360) {
+      errorMessage += 'Hue out of bounds. ';
+    }
+
+    if (saturation >= 0 && saturation <= 1) {
+      saturation *= 100;
+    } else {
+      errorMessage += 'Saturation out of bounds. ';
+    }
+
+    if (lightness >= 0 && lightness <= 1) {
+      lightness *= 100;
+    } else {
+      errorMessage += 'Lightness out of bounds. ';
+    }
+
+    if (alpha != null && (alpha < 0 || alpha > 1)) {
+      errorMessage += 'Alpha out of bounds.';
+    }
+
+    if (isTruthy(errorMessage)) {
+      first.set(errorMessage);
+      return;
+    }
+
+    let res = '';
+    if (hasAlphaValue) {
+      res += 'hsla(';
+    } else {
+      res += 'hsl(';
+    }
+
+    res += hue;
+    res += ', ';
+    res += saturation;
+    res += '%, ';
+    res += lightness;
+
+    if (hasAlphaValue) {
+      res += '%, ';
+      res += alpha;
+      res += ')';
+    } else {
+      res += '%)';
+    }
+
+    first.set(res);
+  }
+}
+
 export class WidthFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {
     const first = vars[0];
@@ -443,6 +518,7 @@ export const CONTENT_FORMATTERS: FormatterTable = {
   'resizedWidthForHeight': new ResizedWidthForHeightFormatter(),
   'squarespaceThumbnailForHeight': new SquarespaceThumbnailForHeightFormatter(),
   'squarespaceThumbnailForWidth': new SquarespaceThumbnailForWidthFormatter(),
+  'website-color': new WebsiteColorFormatter(),
   'width': new WidthFormatter(),
   'video': new VideoFormatter(),
 };


### PR DESCRIPTION
https://squarespace.atlassian.net/browse/CMS-45395

this formatter has just been added in template-compiler: https://github.com/Squarespace/template-compiler/pull/37

currently, the lightness and saturation values of the HSLA model are stored as a decimal value between 0-1. however, CSS needs these values as a percentage (0-100). this formatter takes in an HSLA model from `{ "hue": 360, "saturation": 1, "lightness": 1, "alpha": 0.5 }` and outputs `hsla(360, 100%, 100%, 0.5)`.  if the alpha value is missing, then it outputs the hsl value, like ``{ "hue": 110, "saturation": 0.3, "lightness": 0.4,}` becomes `hsl(110, 30%, 40%, 0.4)`.
