### PR TITLE
[CMS-45395] - update website-color formatter to round to nearest two decimal points

### DIFF
--- a/__tests__/plugins/resources/f-website-color-5.html
+++ b/__tests__/plugins/resources/f-website-color-5.html
@@ -1,8 +1,8 @@
 :JSON
 {
-    "hue": 0.954,
-    "saturation": 0.955,
-    "lightness": 0.956,
+    "hue": 0.956,
+    "saturation": 0.9554,
+    "lightness": 0.9567,
     "alpha": 0.555
 }
 
@@ -11,4 +11,4 @@
 
 :OUTPUT
 
-hsla(1, 95.5%, 95.6%, 0.6)
+hsla(0.96, 95.54%, 95.67%, 0.56)

--- a/src/plugins/formatters.content.ts
+++ b/src/plugins/formatters.content.ts
@@ -410,15 +410,15 @@ export class WebsiteColorFormatter extends Formatter {
       res += 'hsl(';
     }
 
-    res += numberToFixed(hue, 1);
+    res += numberToFixed(hue, 2);
     res += ', ';
-    res += numberToFixed(saturation, 1);
+    res += numberToFixed(saturation, 2);
     res += '%, ';
-    res += numberToFixed(lightness, 1);
+    res += numberToFixed(lightness, 2);
 
     if (hasAlphaValue) {
       res += '%, ';
-      res += numberToFixed(alpha!, 1);
+      res += numberToFixed(alpha!, 2);
       res += ')';
     } else {
       res += '%)';


### PR DESCRIPTION
the website-color formatter originally rounded values to one decimal point.  this PR updates it to two decimal points.