### PR TITLE
[DIG-641] key-by formatter

### DIFF
--- a/__tests__/plugins/formatters.core.test.ts
+++ b/__tests__/plugins/formatters.core.test.ts
@@ -333,6 +333,46 @@ loader.paths('f-json-pretty-%N.html').forEach(path => {
   test(`json pretty - ${path}`, () => loader.execute(path));
 });
 
+test('key-by', () => {
+  let vars = variables([{ id: 1 }]);
+  Core['key-by'].apply([], vars, CTX);
+  expect(vars[0].get()).toEqual({});
+
+  vars = variables({});
+  Core['key-by'].apply(['id'], vars, CTX);
+  expect(vars[0].get()).toEqual({});
+
+  vars = variables([]);
+  Core['key-by'].apply(['id'], vars, CTX);
+  expect(vars[0].get()).toEqual({});
+
+  vars = variables([
+    { id: 1 },
+    { id: 2 },
+    { invalid: 4 },
+  ]);
+  Core['key-by'].apply(['id'], vars, CTX);
+  expect(vars[0].get()).toEqual({
+    1: { id: 1 },
+    2: { id: 2 },
+  });
+
+  vars = variables([
+    { test: [{ deep: 1 }] },
+    { test: [{ deep: 2 }] },
+  ]);
+  Core['key-by'].apply(['test.0.deep'], vars, CTX);
+  expect(vars[0].get()).toEqual({
+    1: { test: [{ deep: 1 }] },
+    2: { test: [{ deep: 2 }] },
+  });
+});
+
+loader.paths('f-key-by-%N.html').forEach(path => {
+  test(`key-by - ${path}`, () => loader.execute(path));
+});
+
+
 loader.paths('f-lookup-%N.html').forEach(path => {
   test(`lookup - ${path}`, () => loader.execute(path));
 });

--- a/__tests__/plugins/resources/f-key-by-1.html
+++ b/__tests__/plugins/resources/f-key-by-1.html
@@ -1,0 +1,26 @@
+:JSON
+{
+	"people": [
+    {
+      "name": "Bob",
+      "emails": {
+        "primary": "bob@example.com",
+        "secondary": "bob2@example.com"
+      }
+    },
+    {
+      "name": "Joe",
+      "emails": {
+        "primary": "joe@example.com",
+        "secondary": "joe2@example.com"
+      }
+    }
+  ]
+}
+
+
+:TEMPLATE
+{people|key-by name|prop Bob.emails.primary}
+
+:OUTPUT
+bob@example.com

--- a/__tests__/plugins/resources/f-key-by-1.html
+++ b/__tests__/plugins/resources/f-key-by-1.html
@@ -1,6 +1,6 @@
 :JSON
 {
-	"people": [
+  "people": [
     {
       "name": "Bob",
       "emails": {

--- a/src/plugins/formatters.core.ts
+++ b/src/plugins/formatters.core.ts
@@ -218,6 +218,28 @@ export class JsonPretty extends Formatter {
   }
 }
 
+export class KeyByFormatter extends Formatter {
+  apply(args: string[], vars: Variable[], ctx: Context): void {
+    const first = vars[0];
+    const path = args[0];
+    const keyByMap: { [key: string]: any } = {};
+
+    if (first.node.type === Type.ARRAY && path) {
+      const splitPath = splitVariable(path);
+
+      for (const val of first.get()) {
+        const nodeAtPath = new Node(val).path(splitPath);
+
+        if (nodeAtPath.type !== Type.MISSING) {
+          keyByMap[nodeAtPath.value] = val;
+        }
+      }
+    }
+
+    first.set(keyByMap);
+  }
+}
+
 export class LookupFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {
     const first = vars[0];
@@ -393,6 +415,7 @@ export const CORE_FORMATTERS: FormatterTable = {
   'iter': new IterFormatter(),
   'json': new JsonFormatter(),
   'json-pretty': new JsonPretty(),
+  'key-by': new KeyByFormatter(),
   'lookup': new LookupFormatter(),
   'mod': new ModFormatter(),
   'output': new OutputFormatter(),


### PR DESCRIPTION
### [DIG-641](https://squarespace.atlassian.net/browse/DIG-641)

### Related PR
https://github.com/Squarespace/template-compiler/pull/43

### Description
- Added new key-by formatter which takes a given array node and tries to map each of the objects inside by the value at the given key path. This can be stored in a var and used in conjunction with the get or prop formatters to allow the user to easily access objects by some key (e.g. id) from anywhere in the template
- Added tests for new key-by formatter