### PR TITLE
[COM-28756]: product scarcity update

### DIFF
--- a/__tests__/plugins/resources/f-product-scarcity-3.html
+++ b/__tests__/plugins/resources/f-product-scarcity-3.html
@@ -23,5 +23,5 @@
 
 :OUTPUT
 <div class="product-scarcity">
-    Only 3 left!
-  </div>
+      Only 3 left!
+    </div>

--- a/__tests__/plugins/resources/f-product-scarcity-4.html
+++ b/__tests__/plugins/resources/f-product-scarcity-4.html
@@ -23,5 +23,5 @@
 
 :OUTPUT
 <div class="product-scarcity">
-    Only 3 left! &lt;img src=x&gt;
-  </div>
+      Only 3 left! &lt;img src=x&gt;
+    </div>

--- a/__tests__/plugins/resources/f-product-scarcity-6.html
+++ b/__tests__/plugins/resources/f-product-scarcity-6.html
@@ -7,18 +7,20 @@
     "560c37c1a7c8465c4a71d99a": {
       "scarcityEnabled": true,
       "scarcityTemplateViews": [{
-        "qtyInStock": 3,
-        "attributes": {
-          "Color": "Red"
-        }
+        "qtyInStock": 3
       }, {
-        "qtyInStock": 7,
+        "qtyInStock": 10,
         "attributes": {
           "Color": "Blue"
         }
+      }, {
+        "qtyInStock": 2,
+        "attributes": {
+          "Color": "Green"
+        }
       }],
       "scarcityText": "Only {qtyInStock} left!",
-      "scarcityShownByDefault": false
+      "scarcityShownByDefault": true
     }
   }
 }
@@ -27,12 +29,18 @@
 {item|product-scarcity}
 
 :OUTPUT
-<div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
+<div class="product-scarcity">
       Only 3 left!
     </div>
   
 
   
     <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
-      Only 7 left!
+      Only 10 left!
+    </div>
+  
+
+  
+    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Green&quot;}" hidden>
+      Only 2 left!
     </div>

--- a/src/plugins/templates/product-scarcity.html
+++ b/src/plugins/templates/product-scarcity.html
@@ -1,5 +1,11 @@
 {.repeated section scarcityTemplateViews}
-  <div class="product-scarcity"{.if scarcityShownByDefault}{.or} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
-    {scarcityText|message qtyInStock:qtyInStock|htmltag}
-  </div>
+  {.equal? @index 1}
+    <div class="product-scarcity"{.if scarcityShownByDefault}{.or} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
+      {scarcityText|message qtyInStock:qtyInStock|htmltag}
+    </div>
+  {.or}
+    <div class="product-scarcity"{.if attributes} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
+      {scarcityText|message qtyInStock:qtyInStock|htmltag}
+    </div>
+  {.end}
 {.end}

--- a/src/plugins/templates/product-scarcity.json
+++ b/src/plugins/templates/product-scarcity.json
@@ -1,13 +1,27 @@
 [17, 1, [
   [4, ["scarcityTemplateViews"], [
-      [0, "\n  <div class=\"product-scarcity\""],
-      [8, [], [["scarcityShownByDefault"]], [], [7, 0, 0, [
-          [0, " data-variant-attributes=\""],
-          [1, [["attributes"]], [["json"], ["htmltag"]]],
-          [0, "\" hidden"]
+      [0, "\n  "],
+      [5, "equal?", [["@index", "1"], " "], [
+          [0, "\n    <div class=\"product-scarcity\""],
+          [8, [], [["scarcityShownByDefault"]], [], [7, 0, 0, [
+              [0, " data-variant-attributes=\""],
+              [1, [["attributes"]], [["json"], ["htmltag"]]],
+              [0, "\" hidden"]
+            ], 3]],
+          [0, ">\n      "],
+          [1, [["scarcityText"]], [["message", [["qtyInStock:qtyInStock"], " "]], ["htmltag"]]],
+          [0, "\n    </div>\n  "]
+        ], [7, 0, 0, [
+          [0, "\n    <div class=\"product-scarcity\""],
+          [8, [], [["attributes"]], [
+              [0, " data-variant-attributes=\""],
+              [1, [["attributes"]], [["json"], ["htmltag"]]],
+              [0, "\" hidden"]
+            ], 3],
+          [0, ">\n      "],
+          [1, [["scarcityText"]], [["message", [["qtyInStock:qtyInStock"], " "]], ["htmltag"]]],
+          [0, "\n    </div>\n  "]
         ], 3]],
-      [0, ">\n    "],
-      [1, [["scarcityText"]], [["message", [["qtyInStock:qtyInStock"], " "]], ["htmltag"]]],
-      [0, "\n  </div>\n"]
+      [0, "\n"]
     ], 3, []]
 ], 18]


### PR DESCRIPTION
This updates product-scarcity formatter to show the first index scarcity without attributes based on a boolean value. Rest of the scarcity will render with or without attributes. The same changes have been made to template-compiler: https://github.com/Squarespace/template-compiler/pull/45