### PR TITLE
[COM-28756]: Update product-scarcity formatter based on attributes

### DIFF
--- a/__tests__/plugins/resources/f-product-scarcity-2.html
+++ b/__tests__/plugins/resources/f-product-scarcity-2.html
@@ -28,11 +28,9 @@
 
 :OUTPUT
 <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
-      Only 3 left!
-    </div>
-  
+    Only 3 left!
+  </div>
 
-  
-    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
-      Only 7 left!
-    </div>
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
+    Only 7 left!
+  </div>

--- a/__tests__/plugins/resources/f-product-scarcity-3.html
+++ b/__tests__/plugins/resources/f-product-scarcity-3.html
@@ -22,6 +22,6 @@
 {item|product-scarcity}
 
 :OUTPUT
-<div class="product-scarcity">
-      Only 3 left!
-    </div>
+<div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
+    Only 3 left!
+  </div>

--- a/__tests__/plugins/resources/f-product-scarcity-4.html
+++ b/__tests__/plugins/resources/f-product-scarcity-4.html
@@ -22,6 +22,6 @@
 {item|product-scarcity}
 
 :OUTPUT
-<div class="product-scarcity">
-      Only 3 left! &lt;img src=x&gt;
-    </div>
+<div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
+    Only 3 left! &lt;img src=x&gt;
+  </div>

--- a/__tests__/plugins/resources/f-product-scarcity-6.html
+++ b/__tests__/plugins/resources/f-product-scarcity-6.html
@@ -30,17 +30,13 @@
 
 :OUTPUT
 <div class="product-scarcity">
-      Only 3 left!
-    </div>
-  
+    Only 3 left!
+  </div>
 
-  
-    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
-      Only 10 left!
-    </div>
-  
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
+    Only 10 left!
+  </div>
 
-  
-    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Green&quot;}" hidden>
-      Only 2 left!
-    </div>
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Green&quot;}" hidden>
+    Only 2 left!
+  </div>

--- a/src/plugins/templates/product-scarcity.html
+++ b/src/plugins/templates/product-scarcity.html
@@ -1,11 +1,5 @@
 {.repeated section scarcityTemplateViews}
-  {.equal? @index 1}
-    <div class="product-scarcity"{.if scarcityShownByDefault}{.or} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
-      {scarcityText|message qtyInStock:qtyInStock|htmltag}
-    </div>
-  {.or}
-    <div class="product-scarcity"{.if attributes} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
-      {scarcityText|message qtyInStock:qtyInStock|htmltag}
-    </div>
-  {.end}
+  <div class="product-scarcity"{.if attributes} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
+    {scarcityText|message qtyInStock:qtyInStock|htmltag}
+  </div>
 {.end}

--- a/src/plugins/templates/product-scarcity.json
+++ b/src/plugins/templates/product-scarcity.json
@@ -1,27 +1,13 @@
 [17, 1, [
   [4, ["scarcityTemplateViews"], [
-      [0, "\n  "],
-      [5, "equal?", [["@index", "1"], " "], [
-          [0, "\n    <div class=\"product-scarcity\""],
-          [8, [], [["scarcityShownByDefault"]], [], [7, 0, 0, [
-              [0, " data-variant-attributes=\""],
-              [1, [["attributes"]], [["json"], ["htmltag"]]],
-              [0, "\" hidden"]
-            ], 3]],
-          [0, ">\n      "],
-          [1, [["scarcityText"]], [["message", [["qtyInStock:qtyInStock"], " "]], ["htmltag"]]],
-          [0, "\n    </div>\n  "]
-        ], [7, 0, 0, [
-          [0, "\n    <div class=\"product-scarcity\""],
-          [8, [], [["attributes"]], [
-              [0, " data-variant-attributes=\""],
-              [1, [["attributes"]], [["json"], ["htmltag"]]],
-              [0, "\" hidden"]
-            ], 3],
-          [0, ">\n      "],
-          [1, [["scarcityText"]], [["message", [["qtyInStock:qtyInStock"], " "]], ["htmltag"]]],
-          [0, "\n    </div>\n  "]
-        ], 3]],
-      [0, "\n"]
+      [0, "\n  <div class=\"product-scarcity\""],
+      [8, [], [["attributes"]], [
+          [0, " data-variant-attributes=\""],
+          [1, [["attributes"]], [["json"], ["htmltag"]]],
+          [0, "\" hidden"]
+        ], 3],
+      [0, ">\n    "],
+      [1, [["scarcityText"]], [["message", [["qtyInStock:qtyInStock"], " "]], ["htmltag"]]],
+      [0, "\n  </div>\n"]
     ], 3, []]
 ], 18]


### PR DESCRIPTION
When attributes exists, we want to hide product-scarcity. When on the PLP there's a edge case where product-status limit is for example, 10. When a product has multiple variants, the summation of variants (TOTAL_STOCK) could be above 10. However, each variant could be below 10. In this case, we're actually showing TOTAL_STOCK as one of the variants.. which is not right. Since for total stock scarcity, attributes is not part of the object, we can assume that scarcity with attributes are a variant while without are total stock.

This change here is to match the change we made in template-compiler: 
https://github.com/Squarespace/template-compiler/pull/46