### PR TITLE
[COM-32536]: Add placeholder for SubscriptionPrice formatter

### DIFF
--- a/src/plugins/formatters.commerce.ts
+++ b/src/plugins/formatters.commerce.ts
@@ -144,6 +144,16 @@ export class ProductPriceFormatter extends Formatter {
   }
 }
 
+export class SubscriptionPriceFormatter extends Formatter {
+  apply(args: string[], vars: Variable[], ctx: Context): void {
+    // Because ProductPriceFormatter has been missing impl for a while now
+    // I think it's ok if we don't implement SubscriptionPriceFormatter
+    // because both formatters would be used together and I don't see
+    // when these formatters would ever be rendered client.
+    // TODO: subscription-price impl if ProductPriceFormatter (above) is also implemented.
+    vars[0].set('not yet implemented');
+  }}
+
 export class ProductQuickViewFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {
     const first = vars[0];
@@ -438,6 +448,7 @@ export const COMMERCE_FORMATTERS: FormatterTable = {
   'percentage-format': new PercentageFormatFormatter(),
   'product-checkout': new ProductCheckoutFormatter(),
   'product-price': new ProductPriceFormatter(),
+  'subscription-price': new SubscriptionPriceFormatter(),
   'product-quick-view': new ProductQuickViewFormatter(),
   'product-restock-notification': new ProductRestockNotificationFormatter(),
   'product-scarcity': new ProductScarcityFormatter(),


### PR DESCRIPTION
Template-compiler implementation: https://github.com/Squarespace/template-compiler/pull/52

I noticed that `product-price` is missing implementation. Since that's been missing for a while and `subscription-price` will be used along side `product-price` on 7.1 PDP, I've decided to not implement `subscription-price` unless `product-price` is also implemented. We also don't client side render these values and strictly only use `template-compiler`. 