### PR TITLE
[COM-33946]: add data-subscription-option-id to Subscribe add to cart btn

### DIFF
--- a/__tests__/plugins/resources/f-add-to-cart-btn-10.html
+++ b/__tests__/plugins/resources/f-add-to-cart-btn-10.html
@@ -1,0 +1,26 @@
+:JSON
+{
+  "item": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "collectionId": "560c37c1a7c8465c4a71d99b",
+    "structuredContent": {
+      "productType": "2",
+      "useCustomAddButtonText": false,
+      "isSubscribable": true,
+      "productSubscriptionOptions" : []
+    }
+  },
+  "localizedStrings": {
+    "productSubscribeText": "SUBSCRIBE"
+  }
+}
+
+:TEMPLATE
+{item|add-to-cart-btn}
+
+:OUTPUT
+<div class="sqs-add-to-cart-button-wrapper" data-animation-role="button">
+  <div class="sqs-add-to-cart-button sqs-suppress-edit-mode sqs-editable-button sqs-button-element--primary " role="button" tabindex="0" data-dynamic-strings data-collection-id="560c37c1a7c8465c4a71d99b" data-item-id="560c37c1a7c8465c4a71d99a" data-product-type="2" data-use-custom-label="false" data-is-subscription="true" data-original-label="SUBSCRIBE" >
+    <div class="sqs-add-to-cart-button-inner">SUBSCRIBE</div>
+  </div>
+</div>

--- a/__tests__/plugins/resources/f-add-to-cart-btn-8.html
+++ b/__tests__/plugins/resources/f-add-to-cart-btn-8.html
@@ -1,0 +1,37 @@
+:JSON
+{
+  "item": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "collectionId": "560c37c1a7c8465c4a71d99b",
+    "structuredContent": {
+      "productType": "2",
+      "useCustomAddButtonText": false,
+      "isSubscribable": true,
+      "productSubscriptionOptions" : [{
+        "id" : "2e0c2fbe-bc48-4a5e-9e0f-bb939576a0aa",
+        "percentageDiscount" : 0,
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "d6803d89-82b8-49a3-ab6d-d9a16c93b5a8",
+          "numBillingCycles" : 0
+        }
+      }]
+    }
+  },
+  "localizedStrings": {
+    "productSubscribeText": "SUBSCRIBE"
+  }
+}
+
+:TEMPLATE
+{item|add-to-cart-btn}
+
+:OUTPUT
+<div class="sqs-add-to-cart-button-wrapper" data-animation-role="button">
+  <div class="sqs-add-to-cart-button sqs-suppress-edit-mode sqs-editable-button sqs-button-element--primary " role="button" tabindex="0" data-dynamic-strings data-collection-id="560c37c1a7c8465c4a71d99b" data-item-id="560c37c1a7c8465c4a71d99a" data-product-type="2" data-use-custom-label="false" data-is-subscription="true" data-original-label="SUBSCRIBE" data-subscription-option-id="2e0c2fbe-bc48-4a5e-9e0f-bb939576a0aa">
+    <div class="sqs-add-to-cart-button-inner">SUBSCRIBE</div>
+  </div>
+</div>

--- a/__tests__/plugins/resources/f-add-to-cart-btn-9.html
+++ b/__tests__/plugins/resources/f-add-to-cart-btn-9.html
@@ -1,0 +1,34 @@
+:JSON
+{
+  "item": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "collectionId": "560c37c1a7c8465c4a71d99b",
+    "structuredContent": {
+      "productType": "2",
+      "useCustomAddButtonText": false,
+      "isSubscribable": false,
+      "productSubscriptionOptions" : [{
+        "id" : "2e0c2fbe-bc48-4a5e-9e0f-bb939576a0aa",
+        "percentageDiscount" : 0,
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "d6803d89-82b8-49a3-ab6d-d9a16c93b5a8",
+          "numBillingCycles" : 0
+        }
+      }]
+    }
+  }
+}
+
+:TEMPLATE
+{item|add-to-cart-btn}
+
+:OUTPUT
+<div class="sqs-add-to-cart-button-wrapper" data-animation-role="button">
+  <div class="sqs-add-to-cart-button sqs-suppress-edit-mode sqs-editable-button sqs-button-element--primary " role="button" tabindex="0" data-dynamic-strings data-collection-id="560c37c1a7c8465c4a71d99b" data-item-id="560c37c1a7c8465c4a71d99a" data-product-type="2" data-use-custom-label="false" data-original-label="Add To Cart" >
+    <div class="sqs-add-to-cart-button-inner">Add To Cart</div>
+  </div>
+</div>

--- a/__tests__/plugins/resources/f-product-checkout-1.html
+++ b/__tests__/plugins/resources/f-product-checkout-1.html
@@ -58,6 +58,9 @@
 
 
 
+
+
+
 <div class="sqs-add-to-cart-button-wrapper" data-animation-role="button">
   <div class="sqs-add-to-cart-button sqs-suppress-edit-mode sqs-editable-button sqs-button-element--primary " role="button" tabindex="0" data-dynamic-strings data-collection-id="" data-item-id="560c37c1a7c8465c4a71d99a" data-product-type="" data-use-custom-label="" data-original-label="Add To Cart" >
     <div class="sqs-add-to-cart-button-inner">Add To Cart</div>

--- a/src/plugins/templates/add-to-cart-btn.html
+++ b/src/plugins/templates/add-to-cart-btn.html
@@ -7,9 +7,12 @@
 {.var @addToCartText localizedStrings.productAddToCartText}
 {.var @subscribeText localizedStrings.productSubscribeText}
 {.var @isSubscribable @content.isSubscribable}
+{.var @productSubscriptionOptions structuredContent.productSubscriptionOptions}
+{.var @subsOTPOptionsCount structuredContent.productSubscriptionOptions|count}
+{.eval @hasProductSubsOptionAndIsSubscribable = @subsOTPOptionsCount && @isSubscribable}
 
 <div class="sqs-add-to-cart-button-wrapper" data-animation-role="button">
-  <div class="sqs-add-to-cart-button sqs-suppress-edit-mode sqs-editable-button sqs-button-element--primary {.if @fieldsFormId && @fieldsForm}use-form{.end}" role="button" tabindex="0" data-dynamic-strings data-collection-id="{collectionId}" data-item-id="{id}" data-product-type="{@productType}" data-use-custom-label="{@useCustom}" {.if @isSubscribable}data-is-subscription="{@isSubscribable}" {.end}data-original-label="{.if @useCustom && @customButton}{@customButton|htmlattr}{.or}{.if @isSubscribable}{.if @subscribeText}{@subscribeText|htmlattr}{.or}Subscribe{.end}{.or}{.if @addToCartText}{@addToCartText|htmlattr}{.or}Add To Cart{.end}{.end}{.end}" {.if @fieldsFormId && @fieldsForm}data-form="{@fieldsForm|json|htmlattr}"{.end}>
+  <div class="sqs-add-to-cart-button sqs-suppress-edit-mode sqs-editable-button sqs-button-element--primary {.if @fieldsFormId && @fieldsForm}use-form{.end}" role="button" tabindex="0" data-dynamic-strings data-collection-id="{collectionId}" data-item-id="{id}" data-product-type="{@productType}" data-use-custom-label="{@useCustom}" {.if @isSubscribable}data-is-subscription="{@isSubscribable}" {.end}data-original-label="{.if @useCustom && @customButton}{@customButton|htmlattr}{.or}{.if @isSubscribable}{.if @subscribeText}{@subscribeText|htmlattr}{.or}Subscribe{.end}{.or}{.if @addToCartText}{@addToCartText|htmlattr}{.or}Add To Cart{.end}{.end}{.end}" {.if @fieldsFormId && @fieldsForm}data-form="{@fieldsForm|json|htmlattr}"{.end}{.if @hasProductSubsOptionAndIsSubscribable}data-subscription-option-id="{@productSubscriptionOptions.0.id}"{.end}>
     <div class="sqs-add-to-cart-button-inner">{.if @useCustom && @customButton}{@customButton|htmltag}{.or}{.if @isSubscribable}{.if @subscribeText}{@subscribeText|htmltag}{.or}Subscribe{.end}{.or}{.if @addToCartText}{@addToCartText|htmltag}{.or}Add To Cart{.end}{.end}{.end}</div>
   </div>
 </div>

--- a/src/plugins/templates/add-to-cart-btn.json
+++ b/src/plugins/templates/add-to-cart-btn.json
@@ -16,6 +16,12 @@
   [6, "@subscribeText", [["localizedStrings", "productSubscribeText"]], 0],
   [0, "\n"],
   [6, "@isSubscribable", [["@content", "isSubscribable"]], 0],
+  [0, "\n"],
+  [6, "@productSubscriptionOptions", [["structuredContent", "productSubscriptionOptions"]], 0],
+  [0, "\n"],
+  [6, "@subsOTPOptionsCount", [["structuredContent", "productSubscriptionOptions"]], [["count"]]],
+  [0, "\n"],
+  [23, "@hasProductSubsOptionAndIsSubscribable = @subsOTPOptionsCount && @isSubscribable"],
   [0, "\n\n<div class=\"sqs-add-to-cart-button-wrapper\" data-animation-role=\"button\">\n  <div class=\"sqs-add-to-cart-button sqs-suppress-edit-mode sqs-editable-button sqs-button-element--primary "],
   [8, [1], [["@fieldsFormId"], ["@fieldsForm"]], [
       [0, "use-form"]
@@ -56,6 +62,11 @@
   [8, [1], [["@fieldsFormId"], ["@fieldsForm"]], [
       [0, "data-form=\""],
       [1, [["@fieldsForm"]], [["json"], ["htmlattr"]]],
+      [0, "\""]
+    ], 3],
+  [8, [], [["@hasProductSubsOptionAndIsSubscribable"]], [
+      [0, "data-subscription-option-id=\""],
+      [1, [["@productSubscriptionOptions", 0, "id"]], 0],
       [0, "\""]
     ], 3],
   [0, ">\n    <div class=\"sqs-add-to-cart-button-inner\">"],


### PR DESCRIPTION
https://squarespace.atlassian.net/browse/COM-33946

Template compiler change: https://github.com/Squarespace/template-compiler/pull/55

We are storing `data-subscription-option-id` on the Subscribe button so we can pass it along to the cart. 