### PR TITLE
[COM-38199]: Update website to featureFlags

### DIFF
--- a/__tests__/plugins/formatters.i18n.test.ts
+++ b/__tests__/plugins/formatters.i18n.test.ts
@@ -119,7 +119,7 @@ test('money', () => {
 
   // Use CLDR mode
   money = { value: '155900.799', currency: 'EUR' };
-  const ctx: any = { website: { useCLDRMoneyFormat: true } };
+  const ctx: any = { featureFlags: { useCLDRMoneyFormat: true } };
   expect(formatMoney(EN, money, ['style:short'], ctx)).toEqual('€156K');
 });
 

--- a/src/plugins/formatters.i18n.ts
+++ b/src/plugins/formatters.i18n.ts
@@ -131,7 +131,7 @@ export class MessageFormatterImpl extends Formatter {
   }
 }
 
-const useCLDRMode = (ctx: Context) => isTruthy(ctx.resolve(['website', 'useCLDRMoneyFormat']));
+const useCLDRMode = (ctx: Context) => isTruthy(ctx.resolve(['featureFlags', 'useCLDRMoneyFormat']));
 
 export class MoneyFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {


### PR DESCRIPTION
## [COM-38199](https://squarespace.atlassian.net/browse/COM-38199)

### Parity with Template-compiler changes to use `featureFlags` instead of `website` 
### https://github.com/Squarespace/template-compiler/pull/36