### PR TITLE
[COM-38695] Port subscription-price formatter from template-compiler

### DIFF
--- a/__tests__/plugins/formatters.commerce.test.ts
+++ b/__tests__/plugins/formatters.commerce.test.ts
@@ -142,3 +142,31 @@ loader.paths('f-variants-select-%N.html').forEach((path) => {
 loader.paths('f-variants-select-subscription.html').forEach((path) => {
   test(`variants select subscription - ${path}`, () => loader.execute(path));
 });
+
+loader.paths('f-subscription-price-multiple-variants-and-multiple-pricing-options.html').forEach((path) => {
+  test(`subscription price multiple variants and multiple pricing options - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-subscription-price-multiple-variants-from-price.html').forEach((path) => {
+  test(`subscription price multiple variants from price - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-subscription-price-on-sale-variants-pricing-options.html').forEach((path) => {
+  test(`subscription price on sale variants pricing options - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-subscription-price-one-on-sale-pricing-option.html').forEach((path) => {
+  test(`subscription price one on sale pricing option - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-subscription-price-one-pricing-option.html').forEach((path) => {
+  test(`subscription price one pricing option - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-subscription-price-variants-with-same-pricing.html').forEach((path) => {
+  test(`subscription price variants with same pricing - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-subscription-price-no-pricing-options.html').forEach((path) => {
+  test(`subscription price no pricing options - ${path}`, () => loader.execute(path));
+});

--- a/__tests__/plugins/resources/f-subscription-price-multiple-variants-and-multiple-pricing-options.html
+++ b/__tests__/plugins/resources/f-subscription-price-multiple-variants-and-multiple-pricing-options.html
@@ -1,0 +1,128 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants": [{
+      "price": 1000,
+      "priceMoney": {
+        "value": "10"
+      },
+      "onSale": false,
+      "pricingOptions": [{
+        "price" : "900",
+        "priceMoney": {
+          "value": "9",
+          "currency": "USD"
+        },
+        "salePrice" : 0,
+        "salePriceMoney": {
+          "value": "0",
+          "currency": "USD"
+        },
+        "percentageDiscount" : 0.1,
+        "onSale" : false,
+        "productSubscriptionOptionId" : "c0733e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 3,
+            "unit" : "MONTH"
+          },
+          "planVersionId" : "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+          "numBillingCycles" : 2
+        }
+      },
+      {
+        "price" : "0",
+        "priceMoney": {
+          "value": "0",
+          "currency": "USD"
+        },
+        "salePrice" : 0,
+        "salePriceMoney": {
+          "value": "0",
+          "currency": "USD"
+        },
+        "percentageDiscount" : 1,
+        "onSale" : false,
+        "productSubscriptionOptionId" : "c0733e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 3,
+            "unit" : "MONTH"
+          },
+          "planVersionId" : "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+          "numBillingCycles" : 2
+        }
+      }]
+    },
+    {
+      "price": 2000,
+      "priceMoney": {
+        "value": "20"
+      },
+      "onSale": false,
+      "pricingOptions": [{
+        "price" : "1800",
+        "priceMoney": {
+          "value": "18",
+          "currency": "USD"
+        },
+        "salePrice" : 0,
+        "salePriceMoney": {
+          "value": 0,
+          "currency": "USD"
+        },
+        "percentageDiscount" : 0.2,
+        "onSale" : false,
+        "productSubscriptionOptionId" : "c56446e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 3,
+            "unit" : "MONTH"
+          },
+          "planVersionId" : "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+          "numBillingCycles" : 2
+        }
+      }]
+    },
+    {
+      "price": 3000,
+      "priceMoney": {
+        "value": "30"
+      },
+      "onSale": false,
+      "pricingOptions": [{
+        "price" : "2400",
+        "priceMoney": {
+          "value": "24",
+          "currency": "USD"
+        },
+        "salePrice" : 0,
+        "salePriceMoney": {
+          "value": 0,
+          "currency": "USD"
+        },
+        "percentageDiscount" : 0.2,
+        "onSale" : false,
+        "productSubscriptionOptionId" : "c9656e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 3,
+            "unit" : "MONTH"
+          },
+          "planVersionId" : "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+          "numBillingCycles" : 2
+        }
+      }]
+    }]
+  }
+}
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+from <span class="sqs-money-native">9.00</span>
+
+</div>

--- a/__tests__/plugins/resources/f-subscription-price-multiple-variants-from-price.html
+++ b/__tests__/plugins/resources/f-subscription-price-multiple-variants-from-price.html
@@ -1,0 +1,724 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants": [{
+        "attributes" : {
+          "Size" : "Small"
+        },
+        "optionValues" : [ {
+          "optionName" : "Size",
+          "value" : "Small"
+        } ],
+        "id" : "d042c448-7b54-48ab-8427-c72d0235fe9d",
+        "sku" : "SQ5275775",
+        "price" : 1000,
+        "salePrice" : 0,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "10.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "unlimited" : true,
+        "qtyInStock" : 0,
+        "width" : 0.0,
+        "height" : 0.0,
+        "weight" : 0.0,
+        "imageIds" : [ ],
+        "images" : [ ],
+        "pricingOptions" : [ {
+          "price" : 950,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.05,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "9.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "b336aef5-ad18-4d41-a4fb-4ca26c72a2d8",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "0d949ebd-2400-4b3c-a48b-62ca7445bf1c",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 500,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.5,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "5.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "87eff39d-b3b7-406d-9bf0-0dd88405a129",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "f2a5b15c-a480-45e7-871c-efedc5a7e3a0",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 850,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.15,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "8.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "eec742cc-c9c5-4cab-af83-19b44daf86b2",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "6a569f1c-0c8b-451d-9514-dfdd32ed4ead",
+            "numBillingCycles" : 6
+          }
+        }, {
+          "price" : 900,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.1,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "9.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "28488def-b922-4a4f-82f8-0f4b5581ed4b",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "ee8e78c6-eefc-4b89-889c-82c1a66daf56",
+            "numBillingCycles" : 12
+          }
+        } ],
+        "len" : 0.0
+      }, {
+        "attributes" : {
+          "Size" : "Medium"
+        },
+        "optionValues" : [ {
+          "optionName" : "Size",
+          "value" : "Medium"
+        } ],
+        "id" : "9edf7df1-a72e-4bfd-aa71-0ba7e38c6578",
+        "sku" : "SQ8658335",
+        "price" : 1000,
+        "salePrice" : 0,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "10.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "unlimited" : true,
+        "qtyInStock" : 0,
+        "width" : 0.0,
+        "height" : 0.0,
+        "weight" : 0.0,
+        "imageIds" : [ ],
+        "images" : [ ],
+        "pricingOptions" : [ {
+          "price" : 950,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.05,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "9.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "b336aef5-ad18-4d41-a4fb-4ca26c72a2d8",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "0d949ebd-2400-4b3c-a48b-62ca7445bf1c",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 500,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.5,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "5.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "87eff39d-b3b7-406d-9bf0-0dd88405a129",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "f2a5b15c-a480-45e7-871c-efedc5a7e3a0",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 850,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.15,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "8.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "eec742cc-c9c5-4cab-af83-19b44daf86b2",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "6a569f1c-0c8b-451d-9514-dfdd32ed4ead",
+            "numBillingCycles" : 6
+          }
+        }, {
+          "price" : 900,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.1,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "9.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "28488def-b922-4a4f-82f8-0f4b5581ed4b",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "ee8e78c6-eefc-4b89-889c-82c1a66daf56",
+            "numBillingCycles" : 12
+          }
+        } ],
+        "len" : 0.0
+      }, {
+        "attributes" : {
+          "Size" : "Large"
+        },
+        "optionValues" : [ {
+          "optionName" : "Size",
+          "value" : "Large"
+        } ],
+        "id" : "1ab48f12-1227-4162-8bdb-58301458bdab",
+        "sku" : "SQ3685168",
+        "price" : 1500,
+        "salePrice" : 0,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "15.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "unlimited" : true,
+        "qtyInStock" : 0,
+        "width" : 0.0,
+        "height" : 0.0,
+        "weight" : 0.0,
+        "imageIds" : [ ],
+        "images" : [ ],
+        "pricingOptions" : [ {
+          "price" : 1425,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.05,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "14.25"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "b336aef5-ad18-4d41-a4fb-4ca26c72a2d8",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "0d949ebd-2400-4b3c-a48b-62ca7445bf1c",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 750,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.5,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "7.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "87eff39d-b3b7-406d-9bf0-0dd88405a129",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "f2a5b15c-a480-45e7-871c-efedc5a7e3a0",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 1275,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.15,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "12.75"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "eec742cc-c9c5-4cab-af83-19b44daf86b2",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "6a569f1c-0c8b-451d-9514-dfdd32ed4ead",
+            "numBillingCycles" : 6
+          }
+        }, {
+          "price" : 1350,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.1,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "13.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "28488def-b922-4a4f-82f8-0f4b5581ed4b",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "ee8e78c6-eefc-4b89-889c-82c1a66daf56",
+            "numBillingCycles" : 12
+          }
+        } ],
+        "len" : 0.0
+      }, {
+        "attributes" : {
+          "Size" : "Extra Small"
+        },
+        "optionValues" : [ {
+          "optionName" : "Size",
+          "value" : "Extra Small"
+        } ],
+        "id" : "02185b14-7f56-4ffc-9680-59da7594ebe6",
+        "sku" : "SQ0142266",
+        "price" : 500,
+        "salePrice" : 0,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "5.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "unlimited" : true,
+        "qtyInStock" : 0,
+        "width" : 0.0,
+        "height" : 0.0,
+        "weight" : 0.0,
+        "imageIds" : [ ],
+        "images" : [ ],
+        "pricingOptions" : [ {
+          "price" : 475,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.05,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "4.75"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "b336aef5-ad18-4d41-a4fb-4ca26c72a2d8",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "0d949ebd-2400-4b3c-a48b-62ca7445bf1c",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 250,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.5,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "2.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "87eff39d-b3b7-406d-9bf0-0dd88405a129",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "f2a5b15c-a480-45e7-871c-efedc5a7e3a0",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 425,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.15,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "4.25"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "eec742cc-c9c5-4cab-af83-19b44daf86b2",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "6a569f1c-0c8b-451d-9514-dfdd32ed4ead",
+            "numBillingCycles" : 6
+          }
+        }, {
+          "price" : 450,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.1,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "4.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "28488def-b922-4a4f-82f8-0f4b5581ed4b",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "ee8e78c6-eefc-4b89-889c-82c1a66daf56",
+            "numBillingCycles" : 12
+          }
+        } ],
+        "len" : 0.0
+      }, {
+        "attributes" : {
+          "Size" : "Extra medium"
+        },
+        "optionValues" : [ {
+          "optionName" : "Size",
+          "value" : "Extra medium"
+        } ],
+        "id" : "07a00952-b877-4aa7-84cb-8ac11198083a",
+        "sku" : "SQ7744206",
+        "price" : 1000,
+        "salePrice" : 0,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "10.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "unlimited" : true,
+        "qtyInStock" : 0,
+        "width" : 0.0,
+        "height" : 0.0,
+        "weight" : 0.0,
+        "imageIds" : [ ],
+        "images" : [ ],
+        "pricingOptions" : [ {
+          "price" : 950,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.05,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "9.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "b336aef5-ad18-4d41-a4fb-4ca26c72a2d8",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "0d949ebd-2400-4b3c-a48b-62ca7445bf1c",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 500,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.5,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "5.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "87eff39d-b3b7-406d-9bf0-0dd88405a129",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "f2a5b15c-a480-45e7-871c-efedc5a7e3a0",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 850,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.15,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "8.50"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "eec742cc-c9c5-4cab-af83-19b44daf86b2",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "6a569f1c-0c8b-451d-9514-dfdd32ed4ead",
+            "numBillingCycles" : 6
+          }
+        }, {
+          "price" : 900,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.1,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "9.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "28488def-b922-4a4f-82f8-0f4b5581ed4b",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "ee8e78c6-eefc-4b89-889c-82c1a66daf56",
+            "numBillingCycles" : 12
+          }
+        } ],
+        "len" : 0.0
+      }, {
+        "attributes" : {
+          "Size" : "extra large"
+        },
+        "optionValues" : [ {
+          "optionName" : "Size",
+          "value" : "extra large"
+        } ],
+        "id" : "f385bd46-db04-432c-aa34-5f87bad59d36",
+        "sku" : "SQ7415626",
+        "price" : 2000,
+        "salePrice" : 0,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "20.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "unlimited" : true,
+        "qtyInStock" : 0,
+        "width" : 0.0,
+        "height" : 0.0,
+        "weight" : 0.0,
+        "imageIds" : [ ],
+        "images" : [ ],
+        "pricingOptions" : [ {
+          "price" : 1900,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.05,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "19.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "b336aef5-ad18-4d41-a4fb-4ca26c72a2d8",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "0d949ebd-2400-4b3c-a48b-62ca7445bf1c",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 1000,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.5,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "10.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "87eff39d-b3b7-406d-9bf0-0dd88405a129",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 1,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "f2a5b15c-a480-45e7-871c-efedc5a7e3a0",
+            "numBillingCycles" : 0
+          }
+        }, {
+          "price" : 1700,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.15,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "17.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "eec742cc-c9c5-4cab-af83-19b44daf86b2",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "WEEK"
+            },
+            "planVersionId" : "6a569f1c-0c8b-451d-9514-dfdd32ed4ead",
+            "numBillingCycles" : 6
+          }
+        }, {
+          "price" : 1800,
+          "salePrice" : 0,
+          "percentageDiscount" : 0.1,
+          "priceMoney" : {
+            "currency" : "USD",
+            "value" : "18.00"
+          },
+          "salePriceMoney" : {
+            "currency" : "USD",
+            "value" : "0.00"
+          },
+          "onSale" : false,
+          "productSubscriptionOptionId" : "28488def-b922-4a4f-82f8-0f4b5581ed4b",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 9,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "ee8e78c6-eefc-4b89-889c-82c1a66daf56",
+            "numBillingCycles" : 12
+          }
+        } ],
+        "len" : 0.0
+      }]
+  }
+}
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+from <span class="sqs-money-native">4.75</span>
+
+</div>

--- a/__tests__/plugins/resources/f-subscription-price-no-pricing-options.html
+++ b/__tests__/plugins/resources/f-subscription-price-no-pricing-options.html
@@ -1,0 +1,20 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants": [{
+      "priceMoney": {
+        "value": "50"
+      },
+      "onSale": false
+    }]
+  }
+}
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+
+</div>

--- a/__tests__/plugins/resources/f-subscription-price-on-sale-variants-pricing-options.html
+++ b/__tests__/plugins/resources/f-subscription-price-on-sale-variants-pricing-options.html
@@ -1,0 +1,156 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants": [
+      {
+        "priceMoney": {
+          "value": "10"
+        },
+        "onSale": false,
+        "pricingOptions": [
+          {
+            "price": "900",
+            "priceMoney": {
+              "value": "9",
+              "currency": "USD"
+            },
+            "salePrice": 0,
+            "salePriceMoney": {
+              "value": "0",
+              "currency": "USD"
+            },
+            "percentageDiscount": 0.1,
+            "onSale": false,
+            "productSubscriptionOptionId": "c0733e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+            "subscriptionPlan": {
+              "billingPeriod": {
+                "value": 3,
+                "unit": "MONTH"
+              },
+              "planVersionId": "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+              "numBillingCycles": 2
+            }
+          },
+          {
+            "price": "0",
+            "priceMoney": {
+              "value": "0",
+              "currency": "USD"
+            },
+            "salePrice": 0,
+            "salePriceMoney": {
+              "value": "0",
+              "currency": "USD"
+            },
+            "percentageDiscount": 1,
+            "onSale": false,
+            "productSubscriptionOptionId": "c0733e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+            "subscriptionPlan": {
+              "billingPeriod": {
+                "value": 3,
+                "unit": "MONTH"
+              },
+              "planVersionId": "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+              "numBillingCycles": 2
+            }
+          }
+        ]
+      },
+      {
+        "priceMoney": {
+          "value": "20"
+        },
+        "salePriceMoney": {
+          "value": "5"
+        },
+        "onSale": true,
+        "pricingOptions": [
+          {
+            "price": "1800",
+            "priceMoney": {
+              "value": "18",
+              "currency": "USD"
+            },
+            "salePrice": "250",
+            "salePriceMoney": {
+              "value": "2.50",
+              "currency": "USD"
+            },
+            "percentageDiscount": 0.5,
+            "onSale": true,
+            "productSubscriptionOptionId": "c56446e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+            "subscriptionPlan": {
+              "billingPeriod": {
+                "value": 3,
+                "unit": "MONTH"
+              },
+              "planVersionId": "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+              "numBillingCycles": 2
+            }
+          },
+          {
+            "price": "1800",
+            "priceMoney": {
+              "value": "18",
+              "currency": "USD"
+            },
+            "salePrice": "300",
+            "salePriceMoney": {
+              "value": "3",
+              "currency": "USD"
+            },
+            "percentageDiscount": 0.2,
+            "onSale": true,
+            "productSubscriptionOptionId": "c56446e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+            "subscriptionPlan": {
+              "billingPeriod": {
+                "value": 3,
+                "unit": "MONTH"
+              },
+              "planVersionId": "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+              "numBillingCycles": 2
+            }
+          }]
+      },
+      {
+        "priceMoney": {
+          "value": "30"
+        },
+        "onSale": false,
+        "pricingOptions": [{
+          "price" : "3400",
+          "priceMoney": {
+            "value": "34",
+            "currency": "USD"
+          },
+          "salePrice" : 0,
+          "salePriceMoney": {
+            "value": 0,
+            "currency": "USD"
+          },
+          "percentageDiscount" : 0.2,
+          "onSale" : false,
+          "productSubscriptionOptionId" : "c9656e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+          "subscriptionPlan" : {
+            "billingPeriod" : {
+              "value" : 3,
+              "unit" : "MONTH"
+            },
+            "planVersionId" : "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+            "numBillingCycles" : 2
+          }
+        }]
+      }]
+  }
+}
+
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+from <span class="sqs-money-native">2.50</span>
+
+</div>

--- a/__tests__/plugins/resources/f-subscription-price-one-on-sale-pricing-option.html
+++ b/__tests__/plugins/resources/f-subscription-price-one-on-sale-pricing-option.html
@@ -1,0 +1,47 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants": [{
+      "priceMoney": {
+        "value": "50"
+      },
+      "salePriceMoney": {
+        "value": "30"
+      },
+      "onSale": true,
+      "pricingOptions": [{
+        "price" : "2250",
+        "priceMoney": {
+          "value": "22.50",
+          "currency": "USD"
+        },
+        "salePrice" : "1500",
+        "salePriceMoney": {
+          "value": "15",
+          "currency": "USD"
+        },
+        "percentageDiscount" : 0.5,
+        "onSale" : true,
+        "productSubscriptionOptionId" : "c0733e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 3,
+            "unit" : "MONTH"
+          },
+          "planVersionId" : "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+          "numBillingCycles" : 2
+        }
+      }]
+    }]
+  }
+}
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">15.00</span> <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">22.50</span></span>
+
+</div>

--- a/__tests__/plugins/resources/f-subscription-price-one-pricing-option.html
+++ b/__tests__/plugins/resources/f-subscription-price-one-pricing-option.html
@@ -1,0 +1,43 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants": [{
+      "priceMoney": {
+        "value": "50"
+      },
+      "onSale": false,
+      "pricingOptions": [{
+        "price" : "4500",
+        "priceMoney": {
+          "value": "45",
+          "currency": "USD"
+        },
+        "salePrice" : "0",
+        "salePriceMoney": {
+          "value": "0",
+          "currency": "USD"
+        },
+        "percentageDiscount" : 0.1,
+        "onSale" : false,
+        "productSubscriptionOptionId" : "c0733e4d-8b1b-400e-a3fc-f2f8fdc21e7f",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 3,
+            "unit" : "MONTH"
+          },
+          "planVersionId" : "3d2d5ea7-a571-4709-b5bc-59223c5a8fbd",
+          "numBillingCycles" : 2
+        }
+      }]
+    }]
+  }
+}
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+<span class="sqs-money-native">45.00</span>
+</div>

--- a/__tests__/plugins/resources/f-subscription-price-variants-with-same-pricing.html
+++ b/__tests__/plugins/resources/f-subscription-price-variants-with-same-pricing.html
@@ -1,0 +1,186 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants" : [ {
+      "attributes" : {
+        "Color" : "Navy"
+      },
+      "optionValues" : [ {
+        "optionName" : "Color",
+        "value" : "Navy"
+      } ],
+      "id" : "2c15e571-96a3-416d-bcbf-b586fb6d86a5",
+      "sku" : "SQ4623793",
+      "price" : 2000,
+      "salePrice" : 0,
+      "priceMoney" : {
+        "currency" : "USD",
+        "value" : "20.00"
+      },
+      "salePriceMoney" : {
+        "currency" : "USD",
+        "value" : "0.00"
+      },
+      "onSale" : false,
+      "unlimited" : false,
+      "qtyInStock" : 1,
+      "width" : 0.0,
+      "height" : 0.0,
+      "weight" : 0.0,
+      "imageIds" : [ ],
+      "images" : [ ],
+      "pricingOptions" : [ {
+        "price" : 1800,
+        "salePrice" : 0,
+        "percentageDiscount" : 0.1,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "18.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "productSubscriptionOptionId" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+          "numBillingCycles" : 5
+        }
+      } ],
+      "len" : 0.0
+    }, {
+      "attributes" : {
+        "Color" : "Red"
+      },
+      "optionValues" : [ {
+        "optionName" : "Color",
+        "value" : "Red"
+      } ],
+      "id" : "30303da6-ae10-4cc4-8639-ebdf1e86e3b8",
+      "sku" : "SQ0235523",
+      "price" : 2000,
+      "salePrice" : 0,
+      "priceMoney" : {
+        "currency" : "USD",
+        "value" : "20.00"
+      },
+      "salePriceMoney" : {
+        "currency" : "USD",
+        "value" : "0.00"
+      },
+      "onSale" : false,
+      "unlimited" : false,
+      "qtyInStock" : 1,
+      "width" : 0.0,
+      "height" : 0.0,
+      "weight" : 0.0,
+      "imageIds" : [ ],
+      "images" : [ ],
+      "pricingOptions" : [ {
+        "price" : 1800,
+        "salePrice" : 0,
+        "percentageDiscount" : 0.1,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "18.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "productSubscriptionOptionId" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+          "numBillingCycles" : 5
+        }
+      } ],
+      "len" : 0.0
+    }, {
+      "attributes" : {
+        "Color" : "Green"
+      },
+      "optionValues" : [ {
+        "optionName" : "Color",
+        "value" : "Green"
+      } ],
+      "id" : "5ac0518a-38f3-4910-ae11-1e90a87c46e5",
+      "sku" : "SQ8531651",
+      "price" : 2000,
+      "salePrice" : 0,
+      "priceMoney" : {
+        "currency" : "USD",
+        "value" : "20.00"
+      },
+      "salePriceMoney" : {
+        "currency" : "USD",
+        "value" : "0.00"
+      },
+      "onSale" : false,
+      "unlimited" : false,
+      "qtyInStock" : 1,
+      "width" : 0.0,
+      "height" : 0.0,
+      "weight" : 0.0,
+      "imageIds" : [ ],
+      "images" : [ ],
+      "pricingOptions" : [ {
+        "price" : 1800,
+        "salePrice" : 0,
+        "percentageDiscount" : 0.1,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "18.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "productSubscriptionOptionId" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+          "numBillingCycles" : 5
+        }
+      } ],
+      "len" : 0.0
+    } ],
+    "variantOptionOrdering" : [ "Color" ],
+    "isSubscribable" : false,
+    "fulfilledExternally" : false,
+    "productSubscriptionOptions" : [ {
+      "id" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+      "percentageDiscount" : 0.1,
+      "subscriptionPlan" : {
+        "billingPeriod" : {
+          "value" : 1,
+          "unit" : "WEEK"
+        },
+        "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+        "numBillingCycles" : 5
+      }
+    }]
+  }
+}
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+<span class="sqs-money-native">18.00</span>
+</div>

--- a/src/plugins/formatters.i18n.ts
+++ b/src/plugins/formatters.i18n.ts
@@ -3,10 +3,9 @@ import { CurrencyType } from '@phensley/cldr-core';
 import { Context } from '../context';
 import { Variable } from '../variable';
 import { FormatterTable } from '../plugin';
-import { isTruthy } from '../node';
 import { Formatter } from '../plugin';
 import { getTimeZone } from './util.timezone';
-import { parseDecimal } from './util.i18n';
+import { parseDecimal, useCLDRMode } from './util.i18n';
 import { currencyOptions, datetimeOptions, decimalOptions, intervalOptions, relativetimeOptions } from './options';
 import { splitVariable } from '../util';
 import { humanizeDate } from './util.content';
@@ -130,8 +129,6 @@ export class MessageFormatterImpl extends Formatter {
     first.set(result);
   }
 }
-
-const useCLDRMode = (ctx: Context) => isTruthy(ctx.resolve(['featureFlags', 'useCLDRMoneyFormat']));
 
 export class MoneyFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {

--- a/src/plugins/templates/subscription-price.html
+++ b/src/plugins/templates/subscription-price.html
@@ -1,0 +1,13 @@
+{.var @originalPriceText localizedStrings.originalPriceText}
+{.var @salePriceText localizedStrings.salePriceText}
+{##
+  CommerceFormatter will provide from-price, sale-price and normal-price.
+  The below will render from-price first if it exists (> 1 variants),
+  sale-price next if from price doesn't exists,
+  normal-price if both from-price and sale-price doesn't exists.
+##}
+<div class="subscription-price">
+{.if formattedFromPrice}{fromText|message fromPrice:formattedFromPrice}
+{.or}{.if formattedSubscriptionSalePrice}<span class="visually-hidden v6-visually-hidden">{.if @salePriceText}{@salePriceText|htmltag}{.or}Sale Price:{.end}</span>{formattedSubscriptionSalePriceText|message price:formattedSubscriptionSalePrice}{.space}<span class="visually-hidden v6-visually-hidden">{.if @originalPriceText}{@originalPriceText|htmltag}{.or}Original Price:{.end}</span><span class="original-price">{formattedNormalSubscriptionPriceText|message price:formattedNormalSubscriptionPrice}</span>
+{.or}{.if formattedNormalSubscriptionPrice}{formattedNormalSubscriptionPriceText|message price:formattedNormalSubscriptionPrice}{.end}{.end}{.end}
+</div>

--- a/src/plugins/templates/subscription-price.json
+++ b/src/plugins/templates/subscription-price.json
@@ -1,0 +1,38 @@
+[17, 1, [
+  [6, "@originalPriceText", [["localizedStrings", "originalPriceText"]], 0],
+  [0, "\n"],
+  [6, "@salePriceText", [["localizedStrings", "salePriceText"]], 0],
+  [0, "\n"],
+  [11, "\n  CommerceFormatter will provide from-price, sale-price and normal-price.\n  The below will render from-price first if it exists (> 1 variants),\n  sale-price next if from price doesn't exists,\n  normal-price if both from-price and sale-price doesn't exists.\n", 1],
+  [0, "\n<div class=\"subscription-price\">\n"],
+  [8, [], [["formattedFromPrice"]], [
+      [1, [["fromText"]], [["message", [["fromPrice:formattedFromPrice"], " "]]]],
+      [0, "\n"]
+    ], [7, 0, 0, [
+      [8, [], [["formattedSubscriptionSalePrice"]], [
+          [0, "<span class=\"visually-hidden v6-visually-hidden\">"],
+          [8, [], [["@salePriceText"]], [
+              [1, [["@salePriceText"]], [["htmltag"]]]
+            ], [7, 0, 0, [
+              [0, "Sale Price:"]
+            ], 3]],
+          [0, "</span>"],
+          [1, [["formattedSubscriptionSalePriceText"]], [["message", [["price:formattedSubscriptionSalePrice"], " "]]]],
+          15,
+          [0, "<span class=\"visually-hidden v6-visually-hidden\">"],
+          [8, [], [["@originalPriceText"]], [
+              [1, [["@originalPriceText"]], [["htmltag"]]]
+            ], [7, 0, 0, [
+              [0, "Original Price:"]
+            ], 3]],
+          [0, "</span><span class=\"original-price\">"],
+          [1, [["formattedNormalSubscriptionPriceText"]], [["message", [["price:formattedNormalSubscriptionPrice"], " "]]]],
+          [0, "</span>\n"]
+        ], [7, 0, 0, [
+          [8, [], [["formattedNormalSubscriptionPrice"]], [
+              [1, [["formattedNormalSubscriptionPriceText"]], [["message", [["price:formattedNormalSubscriptionPrice"], " "]]]]
+            ], 3]
+        ], 3]]
+    ], 3]],
+  [0, "\n</div>"]
+], 18]

--- a/src/plugins/util.commerce.ts
+++ b/src/plugins/util.commerce.ts
@@ -64,7 +64,7 @@ export const getMoneyString = (moneyNode: Node, args: string[], ctx: Context): s
     return ctx.cldr?.Numbers.formatCurrency(amount, currencyCode, currencyOptions(args)) ?? '';
   } else {
     const legacyAmount = getLegacyPriceFromMoneyNode(moneyNode);
-    const numberFormatter = new Intl.NumberFormat('en-US', { minimumFractionDigits: 2 });
+    const numberFormatter = new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
     const formattedAmount = numberFormatter.format(parseFloat(legacyAmount.toString()) / 100);
 
     return `<span class="sqs-money-native">${formattedAmount}</span>`;

--- a/src/plugins/util.i18n.ts
+++ b/src/plugins/util.i18n.ts
@@ -1,4 +1,6 @@
 import { Decimal } from '@phensley/cldr-core';
+import { Context } from '../context';
+import { isTruthy } from '../node';
 
 export const parseDecimal = (s: string | number): Decimal | undefined => {
   try {
@@ -7,3 +9,5 @@ export const parseDecimal = (s: string | number): Decimal | undefined => {
     return undefined;
   }
 };
+
+export const useCLDRMode = (ctx: Context) => isTruthy(ctx.resolve(['featureFlags', 'useCLDRMoneyFormat']));


### PR DESCRIPTION
### Ticket: [COM-38695](https://squarespace.atlassian.net/browse/COM-38695)

### Description
Port subscription-price template, formatter, unimplemented commerce utils, and test cases from template-compiler

### Reasoning
The Commerce Merchandising team is currently working on a project to port the product list and detail pages over to the SDK, and as a result of that, those sections are now going through the client-side rendering pipeline on edit. Because of this, we need this formatter implemented in template engine so that the section re-renders properly on edit

**NOTE:** There will be a follow-up PR for the product-price formatter as well, so it might be good to wait on a release until then @phensley 

### Tests
- [x] Port over all of the tests from template-compiler and ensure that they are all passing