### PR TITLE
[COM-38270]: Remove featureFlags cldr check for Money formatter

### DIFF
--- a/__tests__/plugins/formatters.i18n.test.ts
+++ b/__tests__/plugins/formatters.i18n.test.ts
@@ -117,15 +117,10 @@ test('money', () => {
   const badmoney = { decimalValue: 'abdef', currencyCode: 'USD' };
   expect(formatMoney(EN, badmoney, [])).toEqual('');
 
-  // Use CLDR mode
+  // Use value and currency instead of decimalValue and currencyCode
   money = { value: '155900.799', currency: 'EUR' };
-  let ctx: any = { featureFlags: { useCLDRMoneyFormat: true } };
+  let ctx: any = {};
   expect(formatMoney(EN, money, ['style:short'], ctx)).toEqual('€156K');
-
-  // New money format fails unless in CLDR mode
-  money = { value: '155900.799', currency: 'EUR' };
-  ctx = { featureFlags: { useCLDRMoneyFormat: false } };
-  expect(formatMoney(EN, money, ['style:short'], ctx)).toEqual('');
 });
 
 loader.paths('f-datetime-%N.html').forEach((path) => {

--- a/src/plugins/formatters.i18n.ts
+++ b/src/plugins/formatters.i18n.ts
@@ -3,7 +3,6 @@ import { CurrencyType } from '@phensley/cldr-core';
 import { Context } from '../context';
 import { Variable } from '../variable';
 import { FormatterTable } from '../plugin';
-import { isTruthy } from '../node';
 import { Formatter } from '../plugin';
 import { getTimeZone } from './util.timezone';
 import { parseDecimal } from './util.i18n';
@@ -131,8 +130,6 @@ export class MessageFormatterImpl extends Formatter {
   }
 }
 
-const useCLDRMode = (ctx: Context) => isTruthy(ctx.resolve(['featureFlags', 'useCLDRMoneyFormat']));
-
 export class MoneyFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {
     const first = vars[0];
@@ -140,10 +137,8 @@ export class MoneyFormatter extends Formatter {
     let decimalValue = node.path(['decimalValue']);
     let currencyNode = node.path(['currencyCode']);
     if (decimalValue.isMissing() || currencyNode.isMissing()) {
-      if (useCLDRMode(ctx)) {
-        decimalValue = node.path(['value']);
-        currencyNode = node.path(['currency']);
-      }
+      decimalValue = node.path(['value']);
+      currencyNode = node.path(['currency']);
 
       // No valid money node found.
       if (decimalValue.isMissing() || currencyNode.isMissing()) {


### PR DESCRIPTION
## [COM-38270](https://squarespace.atlassian.net/browse/COM-38270)

## Description
Template-engine Money formatter shouldn't rely on featureFlag check and should be feature parity to the same Template-compiler implementation where it doesn't check feature flag for CLDR: https://github.com/Squarespace/template-compiler/blob/main/core/src/main/java/com/squarespace/template/plugins/platform/i18n/MoneyFormatter.java#L52