### PR TITLE
[COM-38695] Port product-price formatter from template-compiler

### DIFF
--- a/__tests__/plugins/formatters.commerce.test.ts
+++ b/__tests__/plugins/formatters.commerce.test.ts
@@ -71,12 +71,6 @@ loader.paths('f-product-quick-view-%N.html').forEach((path) => {
   test(`product quick view - ${path}`, () => loader.execute(path));
 });
 
-// TODO product-price
-
-// loader.paths('f-product-price-%N.html', 8).forEach((path) => {
-//   test(`product price - ${path}`, () => loader.execute(path));
-// });
-
 loader.paths('f-product-restock-notification-%N.html').forEach((path) => {
   test(`product-restock-notification - ${path}`, () => loader.execute(path));
 });
@@ -169,4 +163,140 @@ loader.paths('f-subscription-price-variants-with-same-pricing.html').forEach((pa
 
 loader.paths('f-subscription-price-no-pricing-options.html').forEach((path) => {
   test(`subscription price no pricing options - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-%N.html').forEach((path) => {
+  test(`product price - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-weekly.html').forEach((path) => {
+  test(`product price subscription weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-bi-weekly.html').forEach((path) => {
+  test(`product price subscription bi-weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-monthly.html').forEach((path) => {
+  test(`product price subscription monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-bi-monthly.html').forEach((path) => {
+  test(`product price subscription bi-monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-from-weekly.html').forEach((path) => {
+  test(`product price subscription from weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-from-bi-weekly.html').forEach((path) => {
+  test(`product price subscription from bi-weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-from-monthly.html').forEach((path) => {
+  test(`product price subscription from monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-from-bi-monthly.html').forEach((path) => {
+  test(`product price subscription from bi-monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-from-weekly-on-sale.html').forEach((path) => {
+  test(`product price subscription from weekly on-sale - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-on-sale-bi-monthly.html').forEach((path) => {
+  test(`product price subscription on-sale bi-monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-on-sale-bi-weekly.html').forEach((path) => {
+  test(`product price subscription on-sale bi-weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-on-sale-monthly.html').forEach((path) => {
+  test(`product price subscription on-sale monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-on-sale-weekly.html').forEach((path) => {
+  test(`product price subscription on-sale weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-weekly-localized.html').forEach((path) => {
+  test(`product price subscription weekly localized - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-weekly-localized-multiple.html').forEach((path) => {
+  test(`product price subscription weekly localized multiple - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-weekly.html').forEach((path) => {
+  test(`product price finite subscription weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-bi-weekly.html').forEach((path) => {
+  test(`product price finite subscription bi-weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-monthly.html').forEach((path) => {
+  test(`product price finite subscription monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-bi-monthly.html').forEach((path) => {
+  test(`product price finite subscription bi-monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-bi-weekly-for-a-year.html').forEach((path) => {
+  test(`product price finite subscription bi-weekly for a year - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-monthly-for-a-year.html').forEach((path) => {
+  test(`product price finite subscription monthly for a year - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-from-weekly.html').forEach((path) => {
+  test(`product price finite subscription from weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-from-bi-weekly.html').forEach((path) => {
+  test(`product price finite subscription from bi-weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-from-monthly.html').forEach((path) => {
+  test(`product price finite subscription from monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-from-bi-monthly.html').forEach((path) => {
+  test(`product price finite subscription from bi-monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-from-weekly-on-sale.html').forEach((path) => {
+  test(`product price finite subscription from weekly on-sale - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-on-sale-bi-monthly.html').forEach((path) => {
+  test(`product price finite subscription on-sale bi-monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-on-sale-bi-weekly.html').forEach((path) => {
+  test(`product price finite subscription on-sale bi-weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-on-sale-monthly.html').forEach((path) => {
+  test(`product price finite subscription on-sale monthly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-on-sale-weekly.html').forEach((path) => {
+  test(`product price finite subscription on-sale weekly - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-weekly-localized.html').forEach((path) => {
+  test(`product price finite subscription weekly localized - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-finite-subscription-weekly-localized-multiple.html').forEach((path) => {
+  test(`product price finite subscription weekly localized multiple - ${path}`, () => loader.execute(path));
+});
+
+loader.paths('f-product-price-subscription-weekly-plan-unavailable.html').forEach((path) => {
+  test(`product price subscription weekly plan unavailable - ${path}`, () => loader.execute(path));
 });

--- a/__tests__/plugins/resources/f-product-price-1.html
+++ b/__tests__/plugins/resources/f-product-price-1.html
@@ -3,8 +3,8 @@
   "structuredContent": {
     "productType": 1,
     "variants": [
-      {"price": 10000},
-      {"price": 20000}
+      {"price": 10000, "priceMoney": { "value": "100" } },
+      {"price": 20000, "priceMoney": { "value": "200" } }
     ]
   }
 }
@@ -13,4 +13,7 @@
 {@|product-price}
 
 :OUTPUT
-<div class="product-price">from <span class="sqs-money-native">100.00</span></div>
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-10.html
+++ b/__tests__/plugins/resources/f-product-price-10.html
@@ -1,10 +1,15 @@
+:PARAMS
+{
+    "locale": "de-DE"
+}
+
 :JSON
 {
     "structuredContent": {
         "productType": 2,
         "priceMoney": {
             "value": "2500",
-            "currency": "USD"
+            "currency": "EUR"
         }
     },
     "website": {
@@ -20,5 +25,5 @@
 
 :OUTPUT
 <div class="product-price">
-$2,500.00
+2.500,00 €
 </div>

--- a/__tests__/plugins/resources/f-product-price-2.html
+++ b/__tests__/plugins/resources/f-product-price-2.html
@@ -3,8 +3,8 @@
   "structuredContent": {
     "productType": 1,
     "variants": [
-      {"price": 10000},
-      {"onSale": true, "salePrice": 5000}
+      {"price": 10000, "priceMoney": { "value": "100" } },
+      {"onSale": true, "salePrice": 5000, "salePriceMoney": { "value": "50" } }
     ]
   }
 }
@@ -13,4 +13,7 @@
 {@|product-price}
 
 :OUTPUT
-<div class="product-price">from <span class="sqs-money-native">50.00</span></div>
+<div class="product-price">
+from <span class="sqs-money-native">50.00</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-3.html
+++ b/__tests__/plugins/resources/f-product-price-3.html
@@ -3,7 +3,7 @@
   "structuredContent": {
     "productType": 1,
     "variants": [
-      {"onSale": true, "salePrice": 5000, "price": 10000}
+      {"onSale": true, "salePriceMoney": { "value": "50.00" }, "priceMoney": { "value": "100.00" } }
     ]
   }
 }
@@ -12,6 +12,7 @@
 {@|product-price}
 
 :OUTPUT
-<div class="product-price"><span class="sqs-money-native">50.00</span> <span class="original-price"><span class="sqs-money-native">100.00</span></span></div>
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">100.00</span></span>
 
-
+</div>

--- a/__tests__/plugins/resources/f-product-price-4.html
+++ b/__tests__/plugins/resources/f-product-price-4.html
@@ -3,7 +3,7 @@
   "structuredContent": {
     "productType": 1,
     "variants": [
-      {"price": 20000}
+      {"priceMoney": { "value": "200.00" } }
     ]
   }
 }
@@ -12,5 +12,6 @@
 {@|product-price}
 
 :OUTPUT
-<div class="product-price"><span class="sqs-money-native">200.00</span></div>
-
+<div class="product-price">
+<span class="sqs-money-native">200.00</span>
+</div>

--- a/__tests__/plugins/resources/f-product-price-5.html
+++ b/__tests__/plugins/resources/f-product-price-5.html
@@ -2,7 +2,7 @@
 {
   "structuredContent": {
     "productType": 2,
-    "priceCents": 20000
+    "priceMoney": { "value": "200" }
   }
 }
 
@@ -10,5 +10,6 @@
 {@|product-price}
 
 :OUTPUT
-<div class="product-price"><span class="sqs-money-native">200.00</span></div>
-
+<div class="product-price">
+<span class="sqs-money-native">200.00</span>
+</div>

--- a/__tests__/plugins/resources/f-product-price-6.html
+++ b/__tests__/plugins/resources/f-product-price-6.html
@@ -3,8 +3,8 @@
   "structuredContent": {
     "productType": 2,
     "onSale": true,
-    "priceCents": 40000,
-    "salePriceCents": 20000
+    "priceMoney": { "value": "400.00" },
+    "salePriceMoney": { "value": "200.00" }
   }
 }
 
@@ -12,6 +12,7 @@
 {@|product-price}
 
 :OUTPUT
-<div class="product-price"><span class="sqs-money-native">200.00</span> <span class="original-price"><span class="sqs-money-native">400.00</span></span></div>
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">200.00</span> <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">400.00</span></span>
 
-
+</div>

--- a/__tests__/plugins/resources/f-product-price-7.html
+++ b/__tests__/plugins/resources/f-product-price-7.html
@@ -9,5 +9,6 @@
 {@|product-price}
 
 :OUTPUT
-<div class="product-price"></div>
+<div class="product-price">
 
+</div>

--- a/__tests__/plugins/resources/f-product-price-9.html
+++ b/__tests__/plugins/resources/f-product-price-9.html
@@ -4,7 +4,7 @@
         "productType": 2,
         "priceMoney": {
             "value": "2500",
-            "currency": "USD"
+            "currency": "EUR"
         }
     },
     "website": {
@@ -20,5 +20,5 @@
 
 :OUTPUT
 <div class="product-price">
-$2,500.00
+€2,500.00
 </div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-bi-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-bi-monthly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 2
+      },
+      "numBillingCycles": 4
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every 2 months for 8 months
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-bi-weekly-for-a-year.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-bi-weekly-for-a-year.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 2
+      },
+      "numBillingCycles": 26
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every 2 weeks for 1 year
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-bi-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-bi-weekly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 2
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every 2 weeks for 12 weeks
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-from-bi-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-from-bi-monthly.html
@@ -1,0 +1,37 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 2
+      },
+      "numBillingCycles": 5
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      },
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every 2 months for 10 months
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-from-bi-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-from-bi-weekly.html
@@ -1,0 +1,37 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 2
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      },
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every 2 weeks for 12 weeks
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-from-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-from-monthly.html
@@ -1,0 +1,37 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 1
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      },
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every month for 6 months
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-from-weekly-on-sale.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-from-weekly-on-sale.html
@@ -1,0 +1,42 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 1
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      },
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        },
+        "onSale": true,
+        "salePrice": 5000,
+        "salePriceMoney": {
+          "value": "50"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">50.00</span> every week for 6 weeks
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-from-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-from-weekly.html
@@ -1,0 +1,37 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 1
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      },
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every week for 6 weeks
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-monthly-for-a-year.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-monthly-for-a-year.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 1
+      },
+      "numBillingCycles": 36
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every month for 3 years
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-monthly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 1
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every month for 6 months
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-bi-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-bi-monthly.html
@@ -1,0 +1,36 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 2
+      },
+      "numBillingCycles": 7
+    },
+    "variants": [
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        },
+        "onSale": true,
+        "salePrice": 5000,
+        "salePriceMoney": {
+          "value": "50"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 months for 14 months <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 months for 14 months</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-bi-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-bi-weekly.html
@@ -1,0 +1,36 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 2
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        },
+        "onSale": true,
+        "salePrice": 5000,
+        "salePriceMoney": {
+          "value": "50"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 weeks for 12 weeks <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 weeks for 12 weeks</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-monthly.html
@@ -1,0 +1,36 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 1
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        },
+        "onSale": true,
+        "salePrice": 5000,
+        "salePriceMoney": {
+          "value": "50"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every month for 6 months <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every month for 6 months</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-on-sale-weekly.html
@@ -1,0 +1,36 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 1
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 20000,
+        "priceMoney": {
+          "value": "200"
+        },
+        "onSale": true,
+        "salePrice": 5000,
+        "salePriceMoney": {
+          "value": "50"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every week for 6 weeks <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every week for 6 weeks</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-weekly-localized-multiple.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-weekly-localized-multiple.html
@@ -1,0 +1,36 @@
+:PARAMS
+{
+  "locale": "en-US"
+}
+
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 5
+    },
+    "numBillingCycles": 3
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  },
+
+  "localizedStrings": {
+    "productPrice__singlePrice__nWeekly__limited__nWeeks" : "{price} every {billingPeriodValue} weeks Other Super Translated for {duration} weeks"
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every 5 weeks Other Super Translated for 15 weeks
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-weekly-localized.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-weekly-localized.html
@@ -1,0 +1,36 @@
+:PARAMS
+{
+  "locale": "en-US"
+}
+
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 1
+    },
+    "numBillingCycles": 8
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  },
+
+  "localizedStrings": {
+    "productPrice__singlePrice__1Weekly__limited__nWeeks" : "{price} every week Super Translated for {duration} weeks"
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every week Super Translated for 8 weeks
+</div>

--- a/__tests__/plugins/resources/f-product-price-finite-subscription-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-finite-subscription-weekly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable": "true",
+    "subscriptionPlan": {
+      "billingPeriod": {
+        "unit": "WEEK",
+        "value": 1
+      },
+      "numBillingCycles": 6
+    },
+    "variants": [
+      {
+        "price": 10000,
+        "priceMoney": {
+          "value": "100"
+        }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every week for 6 weeks
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-bi-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-bi-monthly.html
@@ -1,0 +1,26 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "MONTH",
+      "value" : 2
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every 2 months
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-bi-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-bi-weekly.html
@@ -1,0 +1,26 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 2
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every 2 weeks
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-from-bi-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-from-bi-monthly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "MONTH",
+      "value" : 2
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      },
+      {
+        "price": 20000, "priceMoney": { "value": "200" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every 2 months
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-from-bi-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-from-bi-weekly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 2
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      },
+      {
+        "price": 20000, "priceMoney": { "value": "200" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every 2 weeks
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-from-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-from-monthly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+"subscriptionPlan" : {
+"billingPeriod" : {
+"unit" : "MONTH",
+"value" : 1
+}
+},
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      },
+      {
+        "price": 20000, "priceMoney": { "value": "200" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every month
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-from-weekly-on-sale.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-from-weekly-on-sale.html
@@ -1,0 +1,34 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "isSubscribable" : "true",
+    "subscriptionPlan" : {
+      "billingPeriod" : {
+        "unit" : "WEEK",
+        "value" : 1
+      }
+    },
+    "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      },
+      {
+        "price": 20000,
+        "priceMoney": { "value": "200" },
+        "onSale": true,
+        "salePrice": 5000,
+        "salePriceMoney": { "value": "50" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">50.00</span> every week
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-from-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-from-weekly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 1
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      },
+      {
+        "price": 20000, "priceMoney": { "value": "200" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+from <span class="sqs-money-native">100.00</span> every week
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-monthly.html
@@ -1,0 +1,26 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "MONTH",
+      "value" : 1
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every month
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-on-sale-bi-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-on-sale-bi-monthly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "MONTH",
+      "value" : 2
+    }
+  },
+  "variants": [
+    {
+      "price": 20000,
+      "priceMoney": { "value": "200" },
+      "onSale": true,
+      "salePrice": 5000,
+      "salePriceMoney": { "value": "50" }
+    }
+  ]}
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 months <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 months</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-on-sale-bi-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-on-sale-bi-weekly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 2
+    }
+  },
+  "variants": [
+    {
+      "price": 20000,
+      "priceMoney": { "value": "200" },
+      "onSale": true,
+      "salePrice": 5000,
+      "salePriceMoney": { "value": "50" }
+    }
+  ]}
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 weeks <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 weeks</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-on-sale-monthly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-on-sale-monthly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "MONTH",
+      "value" : 1
+    }
+  },
+  "variants": [
+    {
+      "price": 20000,
+      "priceMoney": { "value": "200" },
+      "onSale": true,
+      "salePrice": 5000,
+      "salePriceMoney": { "value": "50" }
+    }
+  ]}
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every month <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every month</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-on-sale-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-on-sale-weekly.html
@@ -1,0 +1,30 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 1
+    }
+  },
+  "variants": [
+    {
+      "price": 20000,
+      "priceMoney": { "value": "200" },
+      "onSale": true,
+      "salePrice": 5000,
+      "salePriceMoney": { "value": "50" }
+    }
+  ]}
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every week <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every week</span>
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-weekly-localized-multiple.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-weekly-localized-multiple.html
@@ -1,0 +1,35 @@
+:PARAMS
+{
+  "locale": "en-US"
+}
+
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 5
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  },
+
+  "localizedStrings": {
+    "productPrice__singlePrice__nWeekly__indefinite" : "{price} every {billingPeriodValue} months Other Super Translated"
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every 5 months Other Super Translated
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-weekly-localized.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-weekly-localized.html
@@ -1,0 +1,35 @@
+:PARAMS
+{
+  "locale": "en-US"
+}
+
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 1
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  },
+
+  "localizedStrings": {
+    "productPrice__singlePrice__1Weekly__indefinite" : "{price} every week Super Translated"
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every week Super Translated
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-weekly-plan-unavailable.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-weekly-plan-unavailable.html
@@ -1,0 +1,25 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  },
+
+  "localizedStrings": {
+    "productPriceUnavailable" : "Localized: Unavailable"
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+Localized: Unavailable
+
+</div>

--- a/__tests__/plugins/resources/f-product-price-subscription-weekly.html
+++ b/__tests__/plugins/resources/f-product-price-subscription-weekly.html
@@ -1,0 +1,26 @@
+:JSON
+{
+  "structuredContent": {
+  "productType": 1,
+  "isSubscribable" : "true",
+  "subscriptionPlan" : {
+    "billingPeriod" : {
+      "unit" : "WEEK",
+      "value" : 1
+    }
+  },
+  "variants": [
+      {
+        "price": 10000, "priceMoney": { "value": "100" }
+      }
+    ]
+  }
+}
+
+:TEMPLATE
+{@|product-price}
+
+:OUTPUT
+<div class="product-price">
+<span class="sqs-money-native">100.00</span> every week
+</div>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@phensley/timezone": "~1.2.17",
+    "lodash": "^4.17.21",
     "utf8": "^3.0.0"
   },
   "peerDependencies": {
@@ -47,6 +48,7 @@
     "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@types/jest": "^29.5.10",
+    "@types/lodash": "^4.17.13",
     "@types/node": "^20.10.0",
     "@types/utf8": "^3.0.3",
     "beautify-benchmark": "^0.2.4",


### PR DESCRIPTION
### Ticket: [COM-38695](https://squarespace.atlassian.net/browse/COM-38695)

### Prerequisite PRs
- [x] https://github.com/Squarespace/template-engine/pull/29

### Description
Port product-price template, formatter, unimplemented commerce utils, and test cases from template-compiler

**NOTE:** There are a lot of files changed, but most are just test templates that were ported from template-compiler. The main changes are in `src/plugins`.

### Reasoning
The Commerce Merchandising team is currently working on a project to port the product list and detail pages over to the SDK, and as a result of that, those sections are now going through the client-side rendering pipeline on edit. Because of this, we need this formatter implemented in template engine so that the section re-renders properly on edit

**NOTE:** There will be a follow-up PR for the product-price formatter as well, so it might be good to wait on a release until then @phensley 

### Tests
- [x] Port over all of the tests from template-compiler and ensure that they are all passing