### PR TITLE
Add line-breaks formatter and test cases.

### DIFF
--- a/__tests__/plugins/formatters.core.test.ts
+++ b/__tests__/plugins/formatters.core.test.ts
@@ -462,6 +462,26 @@ loader.paths('f-macro-ctx-%N.html').forEach((path) => {
   test(`apply macro ctx - ${path}`, () => loader.execute(path));
 });
 
+test('line-breaks', () => {
+  const ctx = new Context({});
+
+  let vars = variables('');
+  Core['line-breaks'].apply([], vars, ctx);
+  expect(vars[0].get()).toEqual('');
+
+  vars = variables('  \n  ');
+  Core['line-breaks'].apply([], vars, ctx);
+  expect(vars[0].get()).toEqual('  <br/>  ');
+
+  vars = variables('A\nB\n\n\nC\nD');
+  Core['line-breaks'].apply([], vars, ctx);
+  expect(vars[0].get()).toEqual('A<br/>B<br/><br/><br/>C<br/>D');
+});
+
+loader.paths('f-line-breaks-%N.html').forEach((path) => {
+  test(`line-breaks - ${path}`, () => loader.execute(path));
+});
+
 loader.paths('f-output-%N.html').forEach((path) => {
   test(`output - ${path}`, () => loader.execute(path));
 });

--- a/__tests__/plugins/resources/f-line-breaks-1.html
+++ b/__tests__/plugins/resources/f-line-breaks-1.html
@@ -1,0 +1,26 @@
+:JSON
+{
+  "quotes": [
+    "|     \n     |",
+    "",
+    "\"abc\"",
+    "\"A\nB\nC\"",
+    "\"\nLong\n\nquote\n\nwith\n\nseveral\n\n\nline\n\nbreaks\n\""
+  ]
+}
+
+:TEMPLATE
+{.repeated section quotes}
+{@|line-breaks}
+{.end}
+
+:OUTPUT
+|     <br/>     |
+
+
+
+"abc"
+
+"A<br/>B<br/>C"
+
+"<br/>Long<br/><br/>quote<br/><br/>with<br/><br/>several<br/><br/><br/>line<br/><br/>breaks<br/>"

--- a/src/plugins/formatters.core.ts
+++ b/src/plugins/formatters.core.ts
@@ -243,6 +243,17 @@ export class KeyByFormatter extends Formatter {
   }
 }
 
+const NEWLINE = /\n/g;
+
+export class LineBreaksFormatter extends Formatter {
+  apply(args: string[], vars: Variable[], ctx: Context): void {
+    const first = vars[0];
+    const value = first.node.asString();
+    const replacement = value.replace(NEWLINE, '<br/>');
+    first.set(replacement);
+  }
+}
+
 export class LookupFormatter extends Formatter {
   apply(args: string[], vars: Variable[], ctx: Context): void {
     const first = vars[0];
@@ -419,6 +430,7 @@ export const CORE_FORMATTERS: FormatterTable = {
   json: new JsonFormatter(),
   'json-pretty': new JsonPretty(),
   'key-by': new KeyByFormatter(),
+  'line-breaks': new LineBreaksFormatter(),
   lookup: new LookupFormatter(),
   mod: new ModFormatter(),
   output: new OutputFormatter(),


### PR DESCRIPTION
Proposal from Joe Wanko:

JSON-T Formatter Spec: `line-breaks`
Arguments: None - operates on the input string directly
Behavior: Converts newline characters ("\n") to HTML line break tags (`<br/>`).

Rationale: This formatter addresses the HTML whitespace collapsing issue where newlines in text content get compressed into single spaces. Converting \n to <br/> ensures line breaks render correctly in HTML.

Edge Cases: Multiple consecutive newlines: Each "\n" becomes a `<br/>` (e.g., "\n\n" → `<br/><br/>`)
Empty string: Returns empty string
No newlines: Returns string unchanged

```
Input: "Line 1\nLine 2\nLine 3"
Output: "Line 1<br/>Line 2<br/>Line 3"
```

Usage Example
```
{quote | line-breaks}
```
